### PR TITLE
Add utilities for accessing kernel cmd line from anywhere.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,15 @@ ifneq ($(BENCHMARK), none)
 CARGO_OSDK_BUILD_ARGS += --init-args="/benchmark/common/bench_runner.sh $(BENCHMARK) asterinas"
 endif
 
+# If INITARGS is set, it will be passed as arguments to the init process in the VM. By default it is a command to be
+# launched instead of the shell.
+INITARGS ?=
+CARGO_OSDK_BUILD_ARGS += $(foreach ARG, $(INITARGS), --init-args="$(ARG)")
+
+# If KCMDARGS is set, it will be passed as kernel command line args. In the kernel you can access these via KCmdlineArg.
+KCMDARGS ?=
+CARGO_OSDK_BUILD_ARGS += $(foreach ARG, $(KCMDARGS), --kcmd-args="$(ARG)")
+
 ifeq ($(INTEL_TDX), 1)
 BOOT_METHOD = grub-qcow2
 BOOT_PROTOCOL = linux-efi-handover64

--- a/kernel/src/kcmdline.rs
+++ b/kernel/src/kcmdline.rs
@@ -17,8 +17,12 @@ use alloc::{
     vec,
     vec::Vec,
 };
+use core::{any::type_name, str::FromStr};
 
-#[derive(PartialEq, Debug)]
+use log::error;
+use spin::Once;
+
+#[derive(PartialEq, Debug, Clone)]
 struct InitprocArgs {
     path: Option<String>,
     argv: Vec<CString>,
@@ -35,13 +39,12 @@ pub enum ModuleArg {
 }
 
 /// The struct to store the parsed kernel command-line arguments.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KCmdlineArg {
     initproc: InitprocArgs,
     module_args: BTreeMap<String, Vec<ModuleArg>>,
 }
 
-// Define get APIs.
 impl KCmdlineArg {
     /// Gets the path of the initprocess.
     pub fn get_initproc_path(&self) -> Option<&str> {
@@ -59,10 +62,87 @@ impl KCmdlineArg {
     pub fn get_module_args(&self, module: &str) -> Option<&Vec<ModuleArg>> {
         self.module_args.get(module)
     }
+
+    /// Return the value of of an argument for a specific module.
+    ///
+    /// This returns `None` if the argument value isn't available for any reason. If the argument is missing this is
+    /// considered a "normal" missing argument. If the argument is:
+    ///
+    /// * provided as a flag (without a value),
+    /// * does not convert successfully to UTF8,
+    /// * does not parse into type T.
+    ///
+    /// this prints an error and returns `None`. If there is more than once instance of the argument the value with the
+    /// last one will be returned. This is a bit crude as error handling, but it provides a concise and readable way to
+    /// access parameters. If code needs to handle things in a more careful way you can write it against
+    /// [`Self::get_module_args`] instead.
+    ///
+    /// In generally, this should only be used for testing or benchmarking since it is not exposed to users very well. The
+    /// exception would be for very low level configuration where runtime configuration is impossible.
+    pub fn get_module_arg_by_name<T: FromStr>(&self, module: &str, arg_name: &str) -> Option<T> {
+        if let Some(module_args) = self.get_module_args(module) {
+            let mut vals: Vec<_> = module_args.iter().filter_map(|arg| {
+                match arg {
+                    ModuleArg::Arg(name) if name.as_bytes() == arg_name.as_bytes() => {
+                        error!("Argument {arg_name} (expected type {}) was provided without an value. Ignored.", type_name::<T>());
+                        None
+                    },
+                    ModuleArg::KeyVal(name, val) if name.as_bytes() == arg_name.as_bytes() => {
+                        match String::from_utf8(val.as_bytes().to_vec()).map(|s| T::from_str(&s)) {
+                            Ok(Ok(v)) => Some(v),
+                            Ok(Err(e)) => {
+                                error!("Argument {arg_name} (expected type {}) with value {:?} could not be parsed. Ignored.", type_name::<T>(), val);
+                                None
+                            },
+                            Err(e) => {
+                                // This should be unreachable given that a version to and from str has already happened, but no reason to crash.
+                                error!("Argument {arg_name} with value {:?} could not be converted into str with error {}. Ignored.", val, e);
+                                None
+                            }
+
+                        }
+                    }
+                    _ => None,
+                }
+            }).collect();
+            if vals.len() > 1 {
+                error!("Argument {arg_name} provided more than once. Discarding all but last.");
+            }
+            vals.pop()
+        } else {
+            None
+        }
+    }
+
+    /// Returns whether a specific flag (argument without a value) is set for a given module.
+    ///
+    /// This returns `false` if the argument value isn't provided. If the argument provided with a value this prints an
+    /// error and returns `true`. This is a bit crude as error handling, but it provides a concise and readable way to
+    /// access parameters. If code needs to handle things in a more careful way you can write it against
+    /// [`Self::get_module_args`] instead.
+    ///
+    /// In generally, this should only be used for testing or benchmarking since it is not exposed to users very well. The
+    /// exception would be for very low level configuration where runtime configuration is impossible.
+    pub fn get_module_flag_by_name(&self, module: &str, arg_name: &str) -> bool {
+        if let Some(module_args) = self.get_module_args(module) {
+            module_args.iter().any(|arg| match arg {
+                ModuleArg::Arg(name) if name.as_bytes() == arg_name.as_bytes() => true,
+                ModuleArg::KeyVal(name, val) if name.as_bytes() == arg_name.as_bytes() => {
+                    error!(
+                        "Flag {arg_name} was provided with a value {:?}. Ignored.",
+                        val
+                    );
+                    true
+                }
+                _ => false,
+            })
+        } else {
+            false
+        }
+    }
 }
 
-// Splits the command line string by spaces but preserve
-// ones that are protected by double quotes(`"`).
+/// Splits the command line string by spaces but preserve ones that are protected by double quotes(`"`).
 fn split_arg(input: &str) -> impl Iterator<Item = &str> {
     let mut inside_quotes = false;
 
@@ -75,7 +155,7 @@ fn split_arg(input: &str) -> impl Iterator<Item = &str> {
     })
 }
 
-// Define the way to parse a string to `KCmdlineArg`.
+/// Define the way to parse a string to `KCmdlineArg`.
 impl From<&str> for KCmdlineArg {
     fn from(cmdline: &str) -> Self {
         // What we construct.
@@ -179,5 +259,133 @@ impl From<&str> for KCmdlineArg {
         }
 
         result
+    }
+}
+
+static KERNEL_CMD_LINE: Once<KCmdlineArg> = Once::new();
+
+// Set the global kernel command line. This call will be ignored if the command line has already been set.
+pub(crate) fn set_kernel_cmd_line(cmd_line: KCmdlineArg) {
+    if let Some(first) = KERNEL_CMD_LINE.get() {
+        error!("Kernel command line was set more than once. The first was: {first:?}\nThe second was: {cmd_line:?}");
+    }
+    KERNEL_CMD_LINE.call_once(|| cmd_line);
+}
+
+/// Get the global kernel command line. For simple configuration options use this along with
+/// [`KCmdlineArg::get_module_arg_by_name`] and  [`KCmdlineArg::get_module_flag_by_name`]. A reasonable pattern is:
+///
+/// ```no_run
+/// get_kernel_cmd_line().and_then(|cl| cl.get_module_flag_by_name("mod", "flag"))
+/// ```
+///
+/// In generally, this should only be used for testing or benchmarking since it is not exposed to users very well. The
+/// exception would be for very low level configuration where runtime configuration is impossible.
+pub fn get_kernel_cmd_line() -> Option<&'static KCmdlineArg> {
+    KERNEL_CMD_LINE.get()
+}
+
+#[cfg(ktest)]
+mod test {
+    use ostd::prelude::ktest;
+
+    use super::*;
+
+    #[ktest]
+    fn test_get_module_arg_by_name_with_value() {
+        let cmdline = "module.arg=value";
+        let kcmdline = KCmdlineArg::from(cmdline);
+
+        assert_eq!(
+            kcmdline.get_module_arg_by_name::<String>("module", "arg"),
+            Some("value".to_string())
+        );
+    }
+
+    #[ktest]
+    fn test_get_module_arg_by_name_second_with_value() {
+        let cmdline = "module.other module.arg=value";
+        let kcmdline = KCmdlineArg::from(cmdline);
+
+        assert_eq!(
+            kcmdline.get_module_arg_by_name::<String>("module", "arg"),
+            Some("value".to_string())
+        );
+    }
+
+    #[ktest]
+    fn test_get_module_arg_by_name_with_multiple_values() {
+        let cmdline = "module.arg=value module.arg=value2";
+        let kcmdline = KCmdlineArg::from(cmdline);
+
+        assert_eq!(
+            kcmdline.get_module_arg_by_name::<String>("module", "arg"),
+            Some("value2".to_string())
+        );
+    }
+
+    #[ktest]
+    fn test_get_module_arg_by_name_with_value_to_type() {
+        let cmdline = "module.arg=42";
+        let kcmdline = KCmdlineArg::from(cmdline);
+
+        assert_eq!(
+            kcmdline.get_module_arg_by_name::<i32>("module", "arg"),
+            Some(42)
+        );
+    }
+
+    #[ktest]
+    fn test_get_module_arg_by_name_with_invalid_value() {
+        let cmdline = "module.arg=notanint";
+        let kcmdline = KCmdlineArg::from(cmdline);
+
+        assert_eq!(
+            kcmdline.get_module_arg_by_name::<i32>("module", "arg"),
+            None
+        );
+    }
+
+    #[ktest]
+    fn test_get_module_arg_by_name_missing() {
+        let cmdline = "module.arg=value";
+        let kcmdline = KCmdlineArg::from(cmdline);
+
+        assert_eq!(
+            kcmdline.get_module_arg_by_name::<String>("module", "missing"),
+            None
+        );
+    }
+
+    #[ktest]
+    fn test_get_module_flag_by_name() {
+        let cmdline = "module.arg";
+        let kcmdline = KCmdlineArg::from(cmdline);
+
+        assert!(kcmdline.get_module_flag_by_name("module", "arg"));
+    }
+
+    #[ktest]
+    fn test_get_module_flag_by_name_second() {
+        let cmdline = "module.other module.arg";
+        let kcmdline = KCmdlineArg::from(cmdline);
+
+        assert!(kcmdline.get_module_flag_by_name("module", "arg"));
+    }
+
+    #[ktest]
+    fn test_get_module_flag_by_name_missing() {
+        let cmdline = "module.arg";
+        let kcmdline = KCmdlineArg::from(cmdline);
+
+        assert!(!kcmdline.get_module_flag_by_name("module", "missing"));
+    }
+
+    #[ktest]
+    fn test_get_module_flag_by_name_with_value() {
+        let cmdline = "module.arg=value";
+        let kcmdline = KCmdlineArg::from(cmdline);
+
+        assert!(kcmdline.get_module_flag_by_name("module", "arg"));
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -38,7 +38,7 @@ use ostd::{
 use process::{spawn_init_process, Process};
 use sched::SchedPolicy;
 
-use crate::{prelude::*, thread::kernel_thread::ThreadOptions};
+use crate::{kcmdline::set_kernel_cmd_line, prelude::*, thread::kernel_thread::ThreadOptions};
 
 extern crate alloc;
 extern crate lru;
@@ -132,6 +132,10 @@ fn init_thread() {
     // Work queue should be initialized before interrupt is enabled,
     // in case any irq handler uses work queue as bottom half
     thread::work_queue::init();
+
+    let karg: KCmdlineArg = boot_info().kernel_cmdline.as_str().into();
+    set_kernel_cmd_line(karg.clone());
+
     #[cfg(target_arch = "x86_64")]
     net::lazy_init();
     fs::lazy_init();
@@ -151,8 +155,6 @@ fn init_thread() {
     if let Some(console) = FRAMEBUFFER_CONSOLE.get() {
         console.disable();
     };
-
-    let karg: KCmdlineArg = boot_info().kernel_cmdline.as_str().into();
 
     let initproc = spawn_init_process(
         karg.get_initproc_path().unwrap(),


### PR DESCRIPTION
This is to provide a simple canonical way to configure the kernel for testing and benchmarking. This is not meant as a solution for end-user configurations.

As of now there is no code that uses this, but the prefetcher benchmarking process used something very similar and I expect this to be needed in similar efforts frequently.