### PR TITLE
Add Error impls for error types.

### DIFF
--- a/kernel/comps/block/src/bio.rs
+++ b/kernel/comps/block/src/bio.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::fmt::Display;
+
 use align_ext::AlignExt;
 use bitvec::array::BitArray;
 use int_to_c_enum::TryFromInt;
@@ -145,6 +147,14 @@ pub enum BioEnqueueError {
     /// Too big bio
     TooBig,
 }
+
+impl Display for BioEnqueueError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl core::error::Error for BioEnqueueError {}
 
 impl From<BioEnqueueError> for ostd::Error {
     fn from(_error: BioEnqueueError) -> Self {

--- a/ostd/src/error.rs
+++ b/ostd/src/error.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use core::fmt::Display;
+
 use crate::mm::page_table::PageTableError;
 
 /// The error type which is returned from the APIs of this crate.
@@ -24,6 +26,27 @@ pub enum Error {
     /// Error when allocating kernel virtual memory.
     KVirtAreaAllocError,
 }
+
+impl Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidArgs => write!(f, "invalid arguments provided"),
+            Self::NoMemory => write!(f, "insufficient memory available"),
+            Self::PageFault => write!(f, "page fault occurred"),
+            Self::AccessDenied => write!(f, "access to a resource is denied"),
+            Self::IoError => write!(f, "input/output error"),
+            Self::NotEnoughResources => write!(f, "insufficient system resources"),
+            Self::Overflow => write!(f, "arithmetic overflow occurred"),
+            Self::MapAlreadyMappedVaddr => write!(
+                f,
+                "memory mapping already exists for the given virtual address"
+            ),
+            Self::KVirtAreaAllocError => write!(f, "error when allocating kernel virtual memory"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
 
 impl From<PageTableError> for Error {
     fn from(_err: PageTableError) -> Error {


### PR DESCRIPTION
This makes the errors compatible with the `Box<dyn Error>` pattern and future universal error types (snafu::Whatever).