### PR TITLE
Tweak CI configuration and disable benchmarks

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -57,8 +57,11 @@ runs:
       run: |
         # Set common environment variables using GitHub's environment files
         if [[ "${{ inputs.intel_tdx }}" == "true" ]]; then
-          echo "RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static" >> $GITHUB_ENV
-          echo "RUSTUP_UPDATE_ROOT=https://mirrors.ustc.edu.cn/rust-static/rustup" >> $GITHUB_ENV
+          echo "TDX not supported"
+          exit 1
+          # Some kind of special mirror appears to be required.
+          # echo "RUSTUP_DIST_SERVER=" >> $GITHUB_ENV
+          # echo "RUSTUP_UPDATE_ROOT=" >> $GITHUB_ENV
         fi
         
     - name: Run basic tests

--- a/.github/workflows/benchmark_x86.yml
+++ b/.github/workflows/benchmark_x86.yml
@@ -2,9 +2,10 @@ name: "Benchmark x86-64  "
 on:
   # In case of manual trigger, use workflow_dispatch
   workflow_dispatch:
-  schedule:
-    # Schedule to run on every day at 20:00 UTC (04:00 Beijing Time)
-    - cron: '0 20 * * *'
+  # TODO: Enable running benchmark results once we have our own self-hosted environment.
+  # schedule:
+  #   # Schedule to run on every day at 4am CST
+  #   - cron: '0 9 * * *'
 
 jobs:
   Benchmarks:
@@ -122,7 +123,8 @@ jobs:
   Results:
     runs-on: ubuntu-latest
     needs: Benchmarks
-    if: always()
+    # TODO: Enable storing benchmark results
+    if: false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check_licenses.yml
+++ b/.github/workflows/check_licenses.yml
@@ -1,5 +1,6 @@
 name: Check licenses
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: 

--- a/.github/workflows/test_riscv.yml
+++ b/.github/workflows/test_riscv.yml
@@ -2,7 +2,9 @@ name: "Test riscv64  "
 
 on:
   workflow_dispatch:
-  pull_request:
+  # Only run RISCV tests on main so we track it but don't use resources on every PR since we don't really care 
+  # right now.
+  # pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -62,9 +62,10 @@ jobs:
             extra_blocklists: 'blocklists.exfat'
             syscall_test_workdir: '/exfat'
           # SMP Syscall Test (Multiboot2)
-          - test_id: 'syscall-multiboot2-smp4'
-            boot_protocol: 'multiboot2'
-            smp: 4
+          # TODO: Reenable this test once we know why it's hanging
+          # - test_id: 'syscall-multiboot2-smp4'
+          #   boot_protocol: 'multiboot2'
+          #   smp: 4
 
           # General Test (Linux EFI Handover)
           - test_id: 'general-handover64'


### PR DESCRIPTION
This tweaks the CI configuration as we enable it. The notable changes are:

* Disable benchmarks, because they (very reasonably) run on a self-hosted runner.
* Disable RISCV CI on PRs.
* Disable an integration test run which hangs.
* Remove reference to .cn Rust package repo.

As of writing the CI latency is 12 min.

Fixes: #8 