### PR TITLE
Document style guidelines and enable some lints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+This document includes some conventions and style for code and documentation in this repository to
+improve consistency, quality, and maintainablity.
+
+Before you submit changes, you are expected to carefully review your own changes. At a minimum, this
+means testing every change manually and reading the entire diff for mistakes or obvious things that
+could be improved. The lint checkers and tests do not have complete coverage.
+
+## Using AI
+
+If you choose to use AI tools, you are expected to carefully audit, edit, and understand any AI
+generated material you submit (code, comments, documentation, bug reports, ...). You, the human
+developer, are *fully* responsible for it. Remember that carelessness wastes everyone's time, not
+just yours.
+
+## Style Guidelines
+
+See:
+
+* [General Guidelines](docs/src/to-contribute/style-guidelines/general-guidelines.md)
+* [Rust Guidelines](docs/src/to-contribute/style-guidelines/rust-guidelines.md)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,10 +48,15 @@ exclude = [
 ]
 
 [workspace.lints.rust]
-unsafe_op_in_unsafe_fn = "warn"
+unsafe_op_in_unsafe_fn = "deny"
+missing_crate_level_docs = "warn"
 
 [workspace.lints.clippy]
 allow_attributes = "warn"
+# TODO(arthurp,  #48): Enable once the code can pass it.
+# undocumented_unsafe_blocks = "deny"
+# TODO(arthurp,  #49): Enable once the code can pass it.
+# missing_panics_doc = "deny"
 
 # Cargo only looks at the profile settings 
 # in the Cargo.toml manifest at the root of the workspace

--- a/docs/src/to-contribute/style-guidelines/general-guidelines.md
+++ b/docs/src/to-contribute/style-guidelines/general-guidelines.md
@@ -1,1 +1,13 @@
 # General Guidelines
+
+For all text and code files:
+
+* Use a spell checker and do basic editing on documentation and code. (There are spell checkers that
+  check words that are within identifiers like `MisplledWard`. Use one.)
+* Use a line length of 100. **Reason:** This is the default width used by `rustfmt` and consistent
+  length makes text easier to scan.
+* Use `TODO([your handle or name], [issue number or link]): description` when there is a known issue
+  or future task. **Reason:** This allows searching for issues and easily finding more information
+  when they are encountered.
+
+If you encounter violations of these rules in text or code you are editing, go ahead and fix them.

--- a/docs/src/to-contribute/style-guidelines/rust-guidelines.md
+++ b/docs/src/to-contribute/style-guidelines/rust-guidelines.md
@@ -1,17 +1,50 @@
 # Rust Guidelines
 
+We use `rustfmt` and `clippy` for formatting and linting. We use default configurations as much as
+possible.
+
+In addition,
+
+* Use the [general guidelines](general-guidelines.md).
+* Use descriptive local variable names. **Reason:** When other developers read the code they will
+  require less context to understand it.
+* Use `//` comments instead of `/* */` (block) comments.
+* When you need to clone a value into a closure use this pattern:
+```
+fn_taking_closure({
+    let x = x.clone();
+    || {
+        x
+    }
+})
+```
+* Unsafe Rust is not allowed outside of the implementation of OS primitives and core libraries.
+
+If you encounter violations of these rules in code you are editing, go ahead and fix them.
+
 ## API Documentation Guidelines
 
-API documentation describes the meanings and usage of APIs,
-and will be rendered into web pages by rustdoc.
+API documentation describes the meanings and usage of APIs, and is available in developers dev
+environment as well as in the `rustdoc` rendered documentation website.
 
-It is necessary to add documentation to all public APIs,
-including crates, modules, structs, traits, functions, macros, and more.
-The use of the `#[warn(missing_docs)]` lint enforces this rule.
+It is necessary to add documentation to all public APIs, including crates, modules, structs, traits,
+functions, macros, and more. The use of the `#[warn(missing_docs)]` lint enforces this rule.
 
-Asterinas adheres to the API style guidelines of the Rust community.
-The recommended API documentation style can be found at
-[How to write documentation - The rustdoc book](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html).
+As you encounter undocumented parts of the system, take the time to document them, if possible. Add
+`#[warn(missing_docs)]` if possible. Eventually, we would like to enable this for the entire
+codebase.
+
+Asterinas adheres to the API style guidelines of the Rust community. The recommended API
+documentation style can be found at [How to write documentation - The rustdoc
+book](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html).
+
+Make any references to other parts of the code links, when possible. The syntax is:
+```
+[`path::to::thing`]
+```
+For more details see, [Linking to items by
+name](https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html) in the
+`rustdoc` documentation.
 
 ## Lint Guidelines
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 imports_granularity="Crate"
 group_imports="StdExternalCrate"
 reorder_imports=true
+newline_style = "Unix"


### PR DESCRIPTION
* Add CONTRIBUTING.md to link to other docs and set some expectations.
* Expand style guideline documentation.
* Specify newline_style = "Unix", just in case.

FIXES: #7 