### PR TITLE
Add utility for reporting errors instead of panicking.

### DIFF
--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -311,6 +311,24 @@ impl Error {
         }
     }
 
+    // TODO(amp, https://github.com/ldos-project/asterinas/issues/4): This shouldn't use
+    // ENOTRECOVERABLE as that is a specific POSIX error that may not be appropriate here.
+
+    /// An error with no useful information. This is used in place of an empty panic. For example,
+    /// instead of `v.unwrap()` use `v.ok_or_else(Error::unknown)?`.
+    ///
+    /// Use [`Error::unreachable`] if the state is specifically unreachable.
+    pub const fn unknown() -> Error {
+        Error::with_message(Errno::ENOTRECOVERABLE, "unknown failure")
+    }
+
+    /// An error which should never be returned, because it's return is not reachable. This should
+    /// be used in place of [`unreachable!`] when at all possible. For example, instead of
+    /// `v.unwrap()` use `v.ok_or_else(Error::unreachable)?`.
+    pub const fn unreachable() -> Error {
+        Error::with_message(Errno::ENOTRECOVERABLE, "reached unreachable code")
+    }
+
     pub const fn error(&self) -> Errno {
         self.errno
     }

--- a/kernel/src/fs/utils/page_cache.rs
+++ b/kernel/src/fs/utils/page_cache.rs
@@ -407,7 +407,7 @@ impl PageCacheManager {
                 // If there is no previous readahead, an error must have occurred somewhere.
                 assert!(ra_state.request_number() != 0);
                 ra_state.wait_for_prev_readahead(&mut pages)?;
-                pages.get(&idx).unwrap().clone()
+                pages.get(&idx).ok_or_else(Error::unreachable)?.clone()
             } else {
                 // Cond 1.
                 page.clone()


### PR DESCRIPTION
This provides "unknown" and "unreachable" errors for use in place of panics.

This is a small step towards providing an ergonomic replacement for `unwrap` and similar in code returning `Result`.