### PR TITLE
Remove UnwindSafe bound on ORPC servers.

### DIFF
--- a/ostd/src/orpc/oqueue/mod.rs
+++ b/ostd/src/orpc/oqueue/mod.rs
@@ -13,7 +13,6 @@ use alloc::string::String;
 use core::{
     any::Any,
     ops::{Add, Sub},
-    panic::{RefUnwindSafe, UnwindSafe},
 };
 
 use snafu::Snafu;
@@ -54,7 +53,7 @@ impl Sub<usize> for Cursor {
 }
 
 /// A producer handle to a queue. This allow putting values into the queue. Producers are also called producers.
-pub trait Producer<T>: Send + UnwindSafe + Blocker {
+pub trait Producer<T>: Send + Blocker {
     /// Produce a value. This sends `data` to a `Consumer` and makes it available for observation.
     fn produce(&self, data: T);
 
@@ -65,7 +64,7 @@ pub trait Producer<T>: Send + UnwindSafe + Blocker {
 
 /// A consumer handle to a oqueue. This allows taking or receiving values from the oqueue such that no other consumer will
 /// receive the same value ("exactly once to exactly one" semantics).
-pub trait Consumer<T>: Send + UnwindSafe + Blocker {
+pub trait Consumer<T>: Send + Blocker {
     /// Consume a value. This is also called receiving a message.
     ///
     /// This has "exactly once to exactly one consumer" semantics.
@@ -79,7 +78,7 @@ pub trait Consumer<T>: Send + UnwindSafe + Blocker {
 /// consumers or observers from seeing the same value ("exactly once to each" semantics). If a strong observer falls
 /// behind on observing elements it will cause the oqueue to block producers, so strong observers must make sure they
 /// process data promptly.
-pub trait StrongObserver<T>: Send + UnwindSafe + Blocker {
+pub trait StrongObserver<T>: Send + Blocker {
     /// Observe some data. The caller must be subscribed as a strict observer.
     ///
     /// This has "exactly once to each observer" semantics.
@@ -97,7 +96,7 @@ pub trait StrongObserver<T>: Send + UnwindSafe + Blocker {
 /// When used as a blocker this will wake if there is unobserved data in the queue. Code using this should make sure
 /// they always read up to the most recent value before attempting to block. In the simplest case this is:
 /// `observer.weak_observe(self.recent_cursor())`.
-pub trait WeakObserver<T>: Send + UnwindSafe + Blocker {
+pub trait WeakObserver<T>: Send + Blocker {
     /// Observe the data at the given index in the full history of the oqueue. If the data has already been discarded
     /// this will return `None`. This is guaranteed to always return either `None` or the actual value that existed at
     /// the given index.
@@ -160,7 +159,7 @@ pub enum OQueueAttachError {
 /// Weak observers can still observe the messages.
 ///
 /// NOTE: Due to the needs to ORPC, OQueues should generally implement `RefUnwindSafe`.
-pub trait OQueue<T>: Any + Sync + Send + RefUnwindSafe {
+pub trait OQueue<T>: Any + Sync + Send {
     /// Attach to the oqueue as a producer. An error represents either that producers are not supported or that producers
     /// are supported but all supported producers are already attached (for instance, if a second producer tries to
     /// attach to a single-producer oqueue implementation).

--- a/ostd/src/task/mod.rs
+++ b/ostd/src/task/mod.rs
@@ -14,7 +14,6 @@ use core::{
     borrow::Borrow,
     cell::{Cell, RefCell, SyncUnsafeCell},
     ops::Deref,
-    panic::RefUnwindSafe,
     ptr::NonNull,
     sync::atomic::AtomicBool,
 };
@@ -65,7 +64,7 @@ pub struct Task {
 
     schedule_info: TaskScheduleInfo,
 
-    server: ForceSync<RefCell<Option<Arc<dyn Server + Sync + Send + RefUnwindSafe>>>>,
+    server: ForceSync<RefCell<Option<Arc<dyn Server + Sync + Send>>>>,
 }
 
 impl core::fmt::Debug for Task {
@@ -100,9 +99,7 @@ impl Task {
     /// # SAFETY
     ///
     /// This is only safe if it is NOT done concurrently
-    pub unsafe fn server(
-        &self,
-    ) -> &RefCell<Option<Arc<dyn Server + Sync + Send + RefUnwindSafe + 'static>>> {
+    pub unsafe fn server(&self) -> &RefCell<Option<Arc<dyn Server + Sync + Send + 'static>>> {
         unsafe { self.server.get() }
     }
 
@@ -362,9 +359,7 @@ impl CurrentTask {
     }
 
     /// Get a reference to the current server managing this task.
-    pub fn server(
-        &self,
-    ) -> &RefCell<Option<Arc<dyn Server + Sync + Send + RefUnwindSafe + 'static>>> {
+    pub fn server(&self) -> &RefCell<Option<Arc<dyn Server + Sync + Send + 'static>>> {
         // SAFETY: This is the current task, so we have safe access to mutate the server attached to
         // the task. See [`CurrentTask::new`].
         unsafe { self.as_ref().server() }


### PR DESCRIPTION
This removes the requirement that server state implementation UnwindSafe.

## Justification

Server state is already required to be `Sync`, meaning that it has to guarantee the safety of concurrent accesses. Observing the state of data during or after a panic is no different.

When any part of a server panics, all parts of the server should panic. This is a form of server-wide poisoning where all execution in the server is stopped.

Synchronization primitives like `Mutex` can include checks which immediately trigger a panic if the server as a whole has panicked. This would prevent observing the poisoned internals of a Mutex (with some careful ordering of when to set the "panicked flag"). Note: using a panic here instead of `Result` is reasonable because we isolate servers from each others panics.

UnwindSafe is mostly advisory anyway, as it is trying to provide some degree of semantic safety, but Rust in general does not guarantee that. In `std`, it is possible to access the poisoned data (see `PoisonError`). We expect to support this too, so that servers can be restarted without losing their entire state.