### PR TITLE
Add weak this support to ORPC.

### DIFF
--- a/ostd/libs/orpc-macros/src/orpc_server.rs
+++ b/ostd/libs/orpc-macros/src/orpc_server.rs
@@ -90,10 +90,10 @@ pub fn orpc_server_macro_impl(
         impl #generics #ident {
             #[doc = "\
 Create a new instance of Self constructed using `f`. `f` takes the ORPC internal data
-for this server and should return an instance of the server.
+for this server and a weak reference to `self` and should return an instance of the server.
 For example,
 ```ignore
-let server = Self::new_with(|orpc_internal| Self {
+let server = Self::new_with(|orpc_internal, weak_this| Self {
     increment,
     atomic_count,
     orpc_internal,
@@ -101,11 +101,11 @@ let server = Self::new_with(|orpc_internal| Self {
 ```
 "]
             #vis fn new_with(
-                f: impl FnOnce(#orpc_internal_struct_ident) -> Self,
+                f: impl FnOnce(#orpc_internal_struct_ident, &::alloc::sync::Weak<Self>) -> Self,
             ) -> ::alloc::sync::Arc::<Self> {
                 let server = ::alloc::sync::Arc::<Self>::new_cyclic(|weak_this| {
                     let orpc_internal = #internal_init;
-                    f(orpc_internal)
+                    f(orpc_internal, weak_this)
                 });
                 server
             }

--- a/ostd/src/orpc/framework/integration_test.rs
+++ b/ostd/src/orpc/framework/integration_test.rs
@@ -77,7 +77,7 @@ mod test {
             increment: usize,
             atomic_count: AtomicUsize,
         ) -> Result<Arc<ServerAState>, Whatever> {
-            let server = Self::new_with(|orpc_internal| Self {
+            let server = Self::new_with(|orpc_internal, _| Self {
                 increment,
                 atomic_count,
                 orpc_internal,
@@ -211,7 +211,7 @@ mod test {
 
         impl TestServer {
             fn spawn() -> Result<Arc<Self>, Whatever> {
-                let server = Self::new_with(|orpc_internal| Self { orpc_internal });
+                let server = Self::new_with(|orpc_internal, _| Self { orpc_internal });
                 Ok(server)
             }
         }
@@ -248,7 +248,7 @@ mod test {
 
         impl TestServer {
             fn spawn() -> Result<Arc<Self>, Whatever> {
-                let server = Self::new_with(|orpc_internal| Self {
+                let server = Self::new_with(|orpc_internal, _| Self {
                     x: Default::default(),
                     orpc_internal,
                 });


### PR DESCRIPTION
This adds support for servers that are cyclic in that they contain a weak reference to themselves. See Arc::new_cyclic. This is a small extension because the weak this was already used internally.

NOTE: The weak this pattern is arguably an anti-pattern, but it is common and needs to be supported.