### PR TITLE
Add location tracking to disable_preempt for debugging.

### DIFF
--- a/ostd/src/task/preempt/guard.rs
+++ b/ostd/src/task/preempt/guard.rs
@@ -18,6 +18,7 @@ impl !Send for DisabledPreemptGuard {}
 unsafe impl InAtomicMode for DisabledPreemptGuard {}
 
 impl DisabledPreemptGuard {
+    #[track_caller]
     fn new() -> Self {
         super::cpu_local::inc_guard_count();
         Self { _private: () }
@@ -37,6 +38,7 @@ impl Drop for DisabledPreemptGuard {
 }
 
 /// Disables preemption.
+#[track_caller]
 pub fn disable_preempt() -> DisabledPreemptGuard {
     DisabledPreemptGuard::new()
 }


### PR DESCRIPTION
This provides information about the outermost disable_preempt if might_sleep() check fails.

This is disabled in release builds, and should have very low overhead even in debug builds because `core::panic::Location::caller()` is a const function and the stored data is a `'static` reference type.