### PR TITLE
Changed fallocate to dd to successfully build image.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -186,7 +186,7 @@ $(EXT2_IMAGE):
 	@mke2fs $(EXT2_IMAGE)
 
 $(EXFAT_IMAGE):
-	@fallocate -l 64M $(EXFAT_IMAGE)
+	@dd if=/dev/zero of=$(EXFAT_IMAGE) bs=64M count=1
 	@mkfs.exfat $(EXFAT_IMAGE)
 
 .PHONY: build


### PR DESCRIPTION
`make build` would fail on caferri. Changing `fallocate` to `dd` when building the exfat image will successfully build and run. A reference issue is [this](https://github.com/asterinas/asterinas/issues/695)