### PR TITLE
Use posix mode for fallocate

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -186,7 +186,7 @@ $(EXT2_IMAGE):
 	@mke2fs $(EXT2_IMAGE)
 
 $(EXFAT_IMAGE):
-	@fallocate -l 64M $(EXFAT_IMAGE)
+	@fallocate -x -l 64M $(EXFAT_IMAGE)
 	@mkfs.exfat $(EXFAT_IMAGE)
 
 .PHONY: build


### PR DESCRIPTION
Some development systems might not support non-POSIX fallocate, and the image created is pretty small so the slowdown of using POSIX mode is not that significant.