### PR TITLE
Add the ability to provide a closure to be called when a Bio completes.

### DIFF
--- a/kernel/comps/block/src/lib.rs
+++ b/kernel/comps/block/src/lib.rs
@@ -39,6 +39,7 @@ pub mod id;
 mod impl_block_device;
 mod prelude;
 pub mod request_queue;
+mod test_utils;
 
 use component::{ComponentInitError, init_component};
 use ostd::sync::SpinLock;

--- a/kernel/comps/block/src/test_utils.rs
+++ b/kernel/comps/block/src/test_utils.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#![cfg(ktest)]
+
+use crate::{
+    BlockDevice,
+    bio::{BioEnqueueError, BioStatus, SubmittedBio},
+};
+
+/// A block device and immediately completes every submitted request.
+#[derive(Debug)]
+pub struct FakeBlockDevice;
+
+impl BlockDevice for FakeBlockDevice {
+    fn enqueue(&self, bio: SubmittedBio) -> core::result::Result<(), BioEnqueueError> {
+        bio.complete(BioStatus::Complete);
+        Ok(())
+    }
+
+    fn metadata(&self) -> crate::BlockDeviceMeta {
+        todo!()
+    }
+}


### PR DESCRIPTION
This is in addition to the polling and waitlist based existing  implementation. This adds a couple of unit tests.