### PR TITLE
Add ReplyQueue type as the canonical type for ephemeral reply queues.

### DIFF
--- a/ostd/src/orpc/oqueue/mod.rs
+++ b/ostd/src/orpc/oqueue/mod.rs
@@ -8,6 +8,7 @@ pub mod generic_test;
 
 pub mod locking;
 pub mod registry;
+pub mod reply;
 
 use alloc::string::String;
 use core::{

--- a/ostd/src/orpc/oqueue/reply.rs
+++ b/ostd/src/orpc/oqueue/reply.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! A specialized OQueue implementation used only for replies to requests. These OQueues are
+//! expected to be transient and can be optimized for that case.
+
+use alloc::boxed::Box;
+
+use crate::orpc::oqueue::{Consumer, OQueue, OQueueAttachError, Producer};
+
+/// The OQueue implementation to use for ephemeral reply queues.
+///
+/// **NOTE:** This exists as an alias so that it can later be replaced with an optimized
+/// implementation.
+pub type ReplyQueue<T> = super::locking::LockingQueue<T>;
+
+type ReplyHandlePair<T> = (Box<dyn Producer<T>>, Box<dyn Consumer<T>>);
+
+impl<T: Send + 'static> ReplyQueue<T> {
+    /// Construct a producer/consumer pair for handling an async message reply.
+    pub fn new_pair() -> Result<ReplyHandlePair<T>, OQueueAttachError> {
+        let oqueue = ReplyQueue::new(2);
+        Ok((oqueue.attach_producer()?, oqueue.attach_consumer()?))
+    }
+}
+
+#[cfg(ktest)]
+mod test {
+    use super::*;
+    use crate::prelude::*;
+
+    #[ktest]
+    fn test_send_message() {
+        let (producer, consumer) = ReplyQueue::new_pair().unwrap();
+        producer.produce(42);
+        assert_eq!(consumer.consume(), 42);
+    }
+}


### PR DESCRIPTION
This type is currently just the locking queue implementation, but we can replace it with an optimized implementation later.