### PR TITLE
[NFC] Add documentation to page_cache and frame modules.

### DIFF
--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! Frame (physical memory page) management.
+//! # Frame (physical memory page) management.
 //!
 //! A frame is an aligned, contiguous range of bytes in physical memory. The
 //! sizes of base frames and huge frames (that are mapped as "huge pages") are
@@ -30,6 +30,18 @@
 //! module. The reference count and usage of a frame are stored in the metadata
 //! as well, leaving the handle only a pointer to the metadata slot. Users
 //! can create custom metadata types by implementing the [`AnyFrameMeta`] trait.
+//!
+//! ### Relationship to ORPC Servers
+//!
+//! Frame references are shared between servers in multiples places. This is an exception to the
+//! rule against sharing state between servers. However, we cannot practically rule this out,
+//! because both applications and remaining monolithic parts of the kernel assume that this sharing
+//! is possible. ORPC code should avoid reading and writing from shared frames. Doing so should be
+//! viewed as semantically unsafe.
+//!
+//! TODO(arthurp): It should be possible to pass around capabilities to frames most of the time
+//! instead of full references. This would restrict the part of the code that needs to be aware of
+//! the shared nature of frames.
 
 pub mod allocator;
 pub mod linked_list;


### PR DESCRIPTION
This PR purely adds documentation and comments that I wrote during other work. Some of this will be removed in the page_cache refactor, but it may still be useful to have in the code and it should be really quick to review.