### PR TITLE
Use SpinLock instead of Mutex in LockingOQueue

### DIFF
--- a/ostd/src/orpc/oqueue/locking.rs
+++ b/ostd/src/orpc/oqueue/locking.rs
@@ -14,7 +14,7 @@ use super::{
 };
 use crate::{
     prelude::{Arc, Box, Vec},
-    sync::{Mutex, WaitQueue, Waker},
+    sync::{SpinLock, WaitQueue, Waker},
     task::Task,
 };
 
@@ -23,7 +23,7 @@ use crate::{
 /// OQueue.
 pub struct LockingQueue<T> {
     this: Weak<LockingQueue<T>>,
-    inner: Mutex<LockingOQueueInner<T>>,
+    inner: SpinLock<LockingOQueueInner<T>>,
     buffer_size: usize,
     put_wait_queue: WaitQueue,
     read_wait_queue: WaitQueue,
@@ -39,7 +39,7 @@ impl<T> LockingQueue<T> {
         Arc::new_cyclic(|this| LockingQueue {
             this: this.clone(),
             buffer_size,
-            inner: Mutex::new(LockingOQueueInner {
+            inner: SpinLock::new(LockingOQueueInner {
                 buffer: (0..buffer_size).map(|_| None).collect(),
                 n_consumers: 0,
                 head_index: usize::MAX,


### PR DESCRIPTION
This prevents preemption during critical sections which was a problem because OQueues are used from contexts that must not block. Spinning is reasonable, since the lock is only held long enough to access the internal state and never while looping or waiting.