### PR TITLE
Add support for early-boot tests.

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -73,6 +73,7 @@ runs:
         [[ "${{ matrix.id }}" == "compile" ]] && CMD+="make build FEATURES=all"
         [[ "${{ matrix.id }}" == "usermode_test" ]] && CMD+="make test"
         [[ "${{ matrix.id }}" == "ktest" ]] && CMD+="make ktest NETDEV=tap"
+        [[ "${{ matrix.id }}" == "early_boot_test" ]] && CMD+="make early_boot_test"
         [[ -n "${{ inputs.arch }}" ]] && CMD+=" ARCH=${{ inputs.arch }}"
 
         echo "Executing: $CMD"

--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -22,7 +22,7 @@ jobs:
       options: --device=/dev/kvm --privileged
     strategy:
       matrix:
-        id: ['lint', 'compile', 'usermode_test', 'ktest']
+        id: ['lint', 'compile', 'usermode_test', 'ktest', 'early_boot_test']
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "early-boot-test-kernel"
+version = "0.1.0"
+dependencies = [
+ "ostd",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "kernel/libs/typeflags-util",
     "kernel/libs/atomic-integer-wrapper",
     "kernel/libs/xarray",
+    "ostd/tests/early-boot-test-kernel",
 ]
 exclude = [
     "kernel/libs/comp-sys/cargo-component",

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,7 @@ OSDK_CRATES := \
 	osdk/deps/test-kernel \
 	ostd \
 	ostd/libs/linux-bzimage/setup \
+	ostd/tests/early-boot-test-kernel \
 	kernel \
 	kernel/comps/block \
 	kernel/comps/console \
@@ -338,6 +339,12 @@ ktest_%: initramfs $(CARGO_OSDK)
 
 .PHONY: ktest
 ktest: $(addprefix ktest_, $(OSDK_KTEST_TARGETS))
+
+.PHONY: early_boot_test
+early_boot_test: initramfs $(CARGO_OSDK)
+	@dir=ostd/tests/early-boot-test-kernel; \
+	echo "cd $$dir && cargo osdk run"; \
+	(cd $$dir && cargo osdk run) || exit 1; \
 
 # For each non-OSDK crate, invoke a rule which runs docs
 NON_OSDK_DOCS_TARGETS := $(foreach crate, $(NON_OSDK_CRATES), $(subst /,@@,$(crate)))

--- a/ostd/tests/early-boot-test-kernel/Cargo.toml
+++ b/ostd/tests/early-boot-test-kernel/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "early-boot-test-kernel"
+version = "0.1.0"
+edition = "2024"
+description = "Tests for early-boot code that cannot be tested in an initialized ktest environment."
+license = "MPL-2.0"
+
+[dependencies]
+ostd = { path = "../.." }
+
+[profile.dev]
+panic = "unwind"
+
+[lints]
+workspace = true

--- a/ostd/tests/early-boot-test-kernel/src/lib.rs
+++ b/ostd/tests/early-boot-test-kernel/src/lib.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! A minimal early-boot test kernel.
+//!
+//! This should include tests which cannot be ktests because they must executing before the ostd
+//! kernel (or other components) are fully initialized.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+extern crate alloc;
+
+use ostd::{
+    arch::qemu::{QemuExitCode, exit_qemu},
+    orpc::{framework::errors::RPCError, orpc_impl, orpc_server, orpc_trait},
+    prelude::println,
+};
+
+/// The methods used for testing the ORPC framework in early-boot context.
+#[orpc_trait]
+trait TestTrait {
+    fn f(&self) -> Result<usize, RPCError>;
+}
+
+/// A server implementing `TestTrait` for testing.
+#[orpc_server(TestTrait)]
+struct TestServer {}
+
+#[orpc_impl]
+impl TestTrait for TestServer {
+    fn f(&self) -> Result<usize, RPCError> {
+        Ok(42)
+    }
+}
+
+#[ostd::main]
+fn main() {
+    println!("Early-boot tests...");
+
+    let server = TestServer::new_with(|orpc_internal, _| TestServer { orpc_internal });
+
+    assert_eq!(server.f().unwrap(), 42);
+
+    println!("Tests passed.");
+
+    exit_qemu(QemuExitCode::Success);
+}


### PR DESCRIPTION
Add a way to test early-boot code which cannot be tested in a ktest environment.

See #91.

(Initial code generated by Github Co-pilot, but then I cleaned every change.)