### PR TITLE
Fixed the CI that Breaks by the Wrong QEMU Config in RAID1 (#98)

### DIFF
--- a/OSDK.toml
+++ b/OSDK.toml
@@ -62,6 +62,8 @@ qemu.args = """\
     -chardev stdio,id=mux,mux=on,signal=off,logfile=qemu.log \
     -drive if=none,format=raw,id=x0,file=./test/build/ext2.img \
     -drive if=none,format=raw,id=x1,file=./test/build/exfat.img \
+    -drive if=none,format=raw,id=r0,file=./test/build/raid1_0.img \
+    -drive if=none,format=raw,id=r1,file=./test/build/raid1_1.img \
     -device virtio-blk-device,drive=x0 \
     -device virtio-keyboard-device \
     -device virtio-serial-device \

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -81,7 +81,7 @@ pub fn lazy_init() {
 
 fn setup_raid1_device() -> Result<Arc<Raid1Device>> {
     const RAID_DEVICE_NAME: &str = "raid1";
-    const RAID_MEMBER_NAMES: &[&str] = &["raid1_0", "raid1_1"];
+    const RAID_MEMBER_NAMES: &[&str] = &["raid0", "raid1"];
     info!(
         "[raid] initializing RAID-1 '{}' with members {:?}",
         RAID_DEVICE_NAME, RAID_MEMBER_NAMES

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -89,8 +89,8 @@ COMMON_QEMU_ARGS="\
     -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
     -drive if=none,format=raw,id=x0,file=./test/build/ext2.img \
     -drive if=none,format=raw,id=x1,file=./test/build/exfat.img \
-    -drive if=none,format=raw,id=r1_0,file=./test/build/raid1_0.img,cache=directsync \
-    -drive if=none,format=raw,id=r1_1,file=./test/build/raid1_1.img,cache=directsync \
+    -drive if=none,format=raw,id=r0,file=./test/build/raid1_0.img,cache=directsync \
+    -drive if=none,format=raw,id=r1,file=./test/build/raid1_1.img,cache=directsync \
 "
 
 if [ "$1" = "iommu" ]; then
@@ -111,8 +111,8 @@ QEMU_ARGS="\
     -machine q35,kernel-irqchip=split \
     -device virtio-blk-pci,bus=pcie.0,addr=0x6,drive=x0,serial=vext2,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
     -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
-    -device virtio-blk-pci,bus=pcie.0,addr=0x8,drive=r1_0,serial=raid1_0,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
-    -device virtio-blk-pci,bus=pcie.0,addr=0x9,drive=r1_1,serial=raid1_1,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+    -device virtio-blk-pci,bus=pcie.0,addr=0x8,drive=r0,serial=raid0,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+    -device virtio-blk-pci,bus=pcie.0,addr=0x9,drive=r1,serial=raid1,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
     -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off$VIRTIO_NET_FEATURES$IOMMU_DEV_EXTRA \
     -device virtio-serial-pci,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \
     -device virtconsole,chardev=mux \


### PR DESCRIPTION
After adding the RAID1 functionality in #98, an incorrect QEMU configuration breaks the CI pipelines. This is because the names used to configure the QEMU disks did not follow the QEMU convention, and thus QEMU cannot find the device and fails the tests afterwards. 

This PR fixes the issue by using the correct name. 

Related to (#98) 