### PR TITLE
Change weak_observe_range to use an inclusive end

### DIFF
--- a/ostd/src/orpc/oqueue/generic_test.rs
+++ b/ostd/src/orpc/oqueue/generic_test.rs
@@ -21,7 +21,7 @@ use crate::{
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy, Default)]
 pub(crate) struct TestMessage {
-    x: usize,
+    pub(crate) x: usize,
 }
 
 pub(crate) fn test_produce_consume<T: OQueue<TestMessage>>(oqueue: Arc<T>) {


### PR DESCRIPTION
Previously, this used an exclusive end which is unintuitive in this case because we are specifying the set of value we want based on values like "most-recent" and "oldest". Having provide "most-recent + 1" is confusing.

This issue is demostrated by the fact that `weak_observe_recent` was incorrectly implemented.