### PR TITLE
Add support for quickly capturing a stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,6 +1291,7 @@ dependencies = [
  "snafu",
  "spin",
  "tdx-guest",
+ "tinyvec",
  "unwinding",
  "volatile 0.6.1",
  "x86",
@@ -1761,6 +1762,12 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 
 [[package]]
 name = "toml"

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -40,6 +40,7 @@ unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu
 volatile = "0.6.1"
 bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 crossbeam-utils = { version = "0.8.21", default-features = false }
+tinyvec = { version = "1.10"}
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = "0.14.13"
@@ -60,6 +61,7 @@ fdt = { version = "0.1.5", features = ["pretty-printing"] }
 
 [features]
 default = ["cvm_guest"]
+capture_stacks = []
 # The guest OS support for Confidential VMs (CVMs), e.g., Intel TDX
 cvm_guest = ["dep:tdx-guest", "dep:iced-x86"]
 

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -50,6 +50,7 @@ pub mod orpc;
 pub mod panic;
 pub mod prelude;
 pub mod smp;
+pub mod stacktrace;
 pub mod sync;
 pub mod task;
 pub mod timer;

--- a/ostd/src/stacktrace.rs
+++ b/ostd/src/stacktrace.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Utilities for quickly capturing and storing stack traces.
+//!
+//! This provides a way to capture a stack trace at interesting points and print it later if some
+//! error occurs. A good example is capturing the stack when a lock is acquired and then printing
+//! that stack of a deadlock is detected.
+//!
+//! This does nothing and consumes no space unless the `capture_stacks` feature is enabled.
+
+/// The number of stack frames to capture [`CapturedStackTrace`]. This defines the size of that data
+/// structure.
+pub const STACK_DEPTH: usize = 8;
+
+/// A compact stack trace representation with at most [`STACK_DEPTH`] frames.
+#[derive(Clone, Default)]
+pub struct CapturedStackTrace {
+    #[cfg(feature = "capture_stacks")]
+    frames: tinyvec::ArrayVec<[usize; STACK_DEPTH]>,
+}
+
+impl CapturedStackTrace {
+    /// Print the stack trace as a bare series of addresses.
+    pub fn print(&self) {
+        #[cfg(feature = "capture_stacks")]
+        {
+            use crate::early_println;
+            for frame in self.frames.iter() {
+                early_println!("0x{:x}", frame);
+            }
+        }
+    }
+
+    /// Capture the first [`STACK_DEPTH`] frames of the stack. This will skip over the first `skip`
+    /// frames counting from the caller to this function. So, with `skip = 0` the first captured
+    /// frame will be the caller to this function.
+    pub fn capture(skip: usize) -> Self {
+        #[cfg(feature = "capture_stacks")]
+        {
+            use core::ffi::c_void;
+
+            use unwinding::abi::{
+                _Unwind_Backtrace, _Unwind_GetIP, UnwindContext, UnwindReasonCode,
+            };
+
+            struct CallbackData {
+                count: usize,
+                skip: usize,
+                res: CapturedStackTrace,
+            }
+            extern "C" fn callback(
+                unwind_ctx: &UnwindContext<'_>,
+                arg: *mut c_void,
+            ) -> UnwindReasonCode {
+                let data = unsafe { &mut *(arg as *mut CallbackData) };
+                let pc = _Unwind_GetIP(unwind_ctx);
+                if pc == 0 {
+                    return UnwindReasonCode::NORMAL_STOP;
+                }
+                if data.count >= data.skip {
+                    if data.res.frames.try_push(pc).is_some() {
+                        // Stop if there is no more space available in the frames vec.
+                        return UnwindReasonCode::NORMAL_STOP;
+                    }
+                }
+                data.count += 1;
+                UnwindReasonCode::NO_REASON
+            }
+
+            let mut data = CallbackData {
+                skip: skip + 1,
+                count: 0,
+                res: Default::default(),
+            };
+            _Unwind_Backtrace(callback, &mut data as *mut _ as _);
+            data.res
+        }
+        #[cfg(not(feature = "capture_stacks"))]
+        {
+            let _ = skip;
+            Default::default()
+        }
+    }
+}


### PR DESCRIPTION
Add support for quickly capturing the current stack into a fixed size buffer for later use. This is useful for capturing state to provide information for later potential errors.
