### PR TITLE
Use saturating_sub for MPMCOQueue::size

### DIFF
--- a/ostd/src/orpc/oqueue/ringbuffer/mpmc.rs
+++ b/ostd/src/orpc/oqueue/ringbuffer/mpmc.rs
@@ -466,7 +466,9 @@ impl<T, const STRONG_OBSERVERS: bool, const WEAK_OBSERVERS: bool>
     }
 
     fn size(&self) -> usize {
-        self.head.load(Ordering::Relaxed) - self.tail.load(Ordering::Relaxed)
+        self.head
+            .load(Ordering::Relaxed)
+            .saturating_sub(self.tail.load(Ordering::Relaxed))
     }
 
     fn empty(&self) -> bool {


### PR DESCRIPTION
By default `tail` is initialized to a large value, so the subtraction could overflow if no consumers are attached. However, if no consumers are attached, the size should be reported as 0 since it's not guaranteed that we will actually materialize values. `saturating_sub` provides the behavior we need in all cases.