### PR TITLE
Add macros for logging ignored Result::Errs

### DIFF
--- a/kernel/comps/mlsdisk/src/layers/3-log/raw_log.rs
+++ b/kernel/comps/mlsdisk/src/layers/3-log/raw_log.rs
@@ -1085,6 +1085,8 @@ impl TxData for RawLogStoreEdit {}
 mod tests {
     use std::thread::{self, JoinHandle};
 
+    use ostd::{ignore_err, util::log_result};
+
     use super::*;
     use crate::layers::{
         bio::{Buf, MemDisk},

--- a/kernel/comps/mlsdisk/src/layers/5-disk/mlsdisk.rs
+++ b/kernel/comps/mlsdisk/src/layers/5-disk/mlsdisk.rs
@@ -15,7 +15,7 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use ostd::mm::VmIo;
+use ostd::{ignore_err, mm::VmIo};
 use ostd_pod::Pod;
 
 use super::{
@@ -109,7 +109,7 @@ impl<D: BlockSet + 'static> aster_block::BlockDevice for MlsDisk<D> {
             let mut base = start_offset % BLOCK_SIZE;
             bio.segments().iter().for_each(|seg| {
                 let offset = seg.nbytes();
-                let _ = seg.write_bytes(0, &buf.as_slice()[base..base + offset]);
+                ignore_err!(seg.write_bytes(0, &buf.as_slice()[base..base + offset]));
                 base += offset;
             });
             BioStatus::Complete
@@ -136,7 +136,7 @@ impl<D: BlockSet + 'static> aster_block::BlockDevice for MlsDisk<D> {
 
             bio.segments().iter().for_each(|seg| {
                 let offset = seg.nbytes();
-                let _ = seg.read_bytes(0, &mut buf.as_mut_slice()[base..base + offset]);
+                ignore_err!(seg.read_bytes(0, &mut buf.as_mut_slice()[base..base + offset]));
                 base += offset;
             });
 

--- a/kernel/comps/virtio/src/device/block/device.rs
+++ b/kernel/comps/virtio/src/device/block/device.rs
@@ -18,7 +18,7 @@ use aster_block::{
 use id_alloc::IdAlloc;
 use log::{debug, info};
 use ostd::{
-    Pod,
+    Pod, ignore_err,
     mm::{DmaDirection, DmaStream, DmaStreamSlice, FrameAllocOptions, VmIo},
     sync::SpinLock,
     trap::TrapFrame,
@@ -293,7 +293,7 @@ impl DeviceInner {
         let device_id = {
             device_id_slice.sync().unwrap();
             let mut device_id = vec![0u8; MAX_ID_LENGTH];
-            let _ = device_id_slice.read_bytes(0, &mut device_id);
+            ignore_err!(device_id_slice.read_bytes(0, &mut device_id));
             let len = device_id
                 .iter()
                 .position(|&b| b == 0)

--- a/kernel/src/device/tty/n_tty.rs
+++ b/kernel/src/device/tty/n_tty.rs
@@ -66,6 +66,8 @@ fn create_n_tty(index: u32, device: Arc<dyn AnyConsoleDevice>) -> Arc<Tty<Consol
         move |mut reader: VmReader<Infallible>| {
             let mut chs = vec![0u8; reader.remain()];
             reader.read(&mut VmWriter::from(chs.as_mut_slice()));
+            // This drops the error without reporting, because attempting to report a tty error by
+            // printing could cause problems.
             let _ = tty.push_input(chs.as_slice());
         },
     )));

--- a/kernel/src/fs/epoll/file.rs
+++ b/kernel/src/fs/epoll/file.rs
@@ -4,7 +4,7 @@ use alloc::{collections::btree_set::BTreeSet, sync::Arc};
 use core::{borrow::Borrow, time::Duration};
 
 use keyable_arc::KeyableWeak;
-use ostd::sync::Mutex;
+use ostd::{ignore_err, sync::Mutex};
 
 use super::{
     EpollCtl, EpollEvent, EpollFlags,
@@ -222,8 +222,11 @@ impl EpollFile {
                 // remove the entry at the same time, and we run into some race conditions.
                 //
                 // However, this has very limited impact because we will never remove a wrong entry. So
-                // the error can be silently ignored.
-                let _ = self.del_interest(entry.fd(), entry.file_weak().clone());
+                // the error is only logged.
+                ignore_err!(
+                    self.del_interest(entry.fd(), entry.file_weak().clone()),
+                    log::Level::Info
+                );
                 continue;
             };
 

--- a/kernel/src/process/exit.rs
+++ b/kernel/src/process/exit.rs
@@ -2,6 +2,8 @@
 
 use core::sync::atomic::Ordering;
 
+use ostd::ignore_err;
+
 use super::{Pid, Process, process_table};
 use crate::{prelude::*, process::signal::signals::kernel::KernelSignal};
 
@@ -110,7 +112,9 @@ fn move_children_to_reaper_process(current_process: &Process) {
         return;
     };
 
-    let _ = move_process_children(current_process, &init_process);
+    ignore_err!(
+        move_process_children(current_process, &init_process).map_err(|_| "failed to move")
+    );
 }
 
 /// Sends a child-death signal to the parent.

--- a/kernel/src/syscall/madvise.rs
+++ b/kernel/src/syscall/madvise.rs
@@ -54,6 +54,7 @@ fn madv_free(start: Vaddr, end: Vaddr, ctx: &Context) -> Result<()> {
     let user_space = ctx.user_space();
     let root_vmar = user_space.root_vmar();
     let advised_range = start..end;
+    // This is advise, so failing silently is acceptable.
     let _ = root_vmar.remove_mapping(advised_range);
 
     Ok(())

--- a/kernel/src/syscall/msync.rs
+++ b/kernel/src/syscall/msync.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use align_ext::AlignExt;
+use ostd::ignore_err;
 
 use super::SyscallReturn;
 use crate::{prelude::*, thread::kernel_thread::ThreadOptions};
@@ -85,7 +86,7 @@ pub fn sys_msync(start: Vaddr, size: usize, flag: i32, ctx: &Context) -> Result<
     let task_fn = move || {
         for inode in inodes {
             // TODO: Sync a necessary range instead of syncing the whole inode.
-            let _ = inode.sync_all();
+            ignore_err!(inode.sync_all());
         }
     };
 

--- a/ostd/src/util/ignore_error.rs
+++ b/ostd/src/util/ignore_error.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Logging and error reporting utilities for [`Result`]s.
+//!
+//! Sometimes [`Result::Err`] needs to be ignored. However, the error should not be dropped since it
+//! might be important to know it happened. These macros provide a way both silence the warning
+//! about unused [`Result`] and log the error if once occurs.
+
+// TODO(arthurp): clippy::format_args is broken by another lint, see
+// https://github.com/rust-lang/rust/issues/98291#issuecomment-2673505799. When we figure out how,
+// we should use it for these macros to improve the tooling help for using these macros.
+
+/// `ignore_err!(expr)` logs the error if `expr` is `Err` and otherwise does nothing. This should be
+/// used when an error happens, but the code needs to or can continue executing. The text provided
+/// should describe the errors effect on the system.
+///
+/// The macro supports an optional log level and additional message. Using a different log level is
+/// useful in cases where an error may occur frequently or is not very important. The default level
+/// is `Error`. An additional message may be useful to specify why the error was ignored.
+///
+/// ```no_run
+/// # use log::Level;
+/// # let expr: core::result::Result<u16, usize> = Err(32);
+/// # let x = 42;
+/// ignore_err!(expr)
+/// ignore_err!(expr, Level::Info)
+/// ignore_err!(expr, Level::Info, "additional info {}", x)
+/// ```
+///
+/// This macro requires that the error implement `Display`. If it does not, use [`Result::map_err`]
+/// to convert it to something which does.
+#[macro_export]
+macro_rules! ignore_err {
+    ($result:expr) => {
+        ignore_err!($result, ::log::Level::Error)
+    };
+    ($result:expr, $level:expr) => {{
+        if let Err(e) = $result {
+            ::log::log!($level, "error ignored: {}", e)
+        }
+    }};
+    ($result:expr, $level:expr, $($args:tt)+) => {{
+        if let Err(e) = $result {
+            ::log::log!($level, "error ignored: {}: {}", alloc::format!($($args)+), e)
+        }
+    }};
+}
+
+#[cfg(ktest)]
+mod test {
+    use log::Level;
+
+    use crate::prelude::*;
+
+    static ERROR: core::result::Result<u16, usize> = Err(32);
+
+    #[ktest]
+    fn test_ignore_err() {
+        ignore_err!(ERROR);
+        ignore_err!(ERROR, Level::Info);
+        ignore_err!(ERROR, Level::Info, "not able to {}", "test");
+    }
+}

--- a/ostd/src/util/mod.rs
+++ b/ostd/src/util/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod callback_counter;
 mod either;
+pub mod ignore_error;
 mod macros;
 pub(crate) mod ops;
 pub(crate) mod range_alloc;


### PR DESCRIPTION
These macros provide a way to drop errors while still providing debuggability if the error DOES happen. The macros also serve as a marker that an error is being dropped.