### PR TITLE
Fix Ext2 Filesystem Read Path under Direct Disk IO

### DIFF
--- a/kernel/comps/block/src/bio.rs
+++ b/kernel/comps/block/src/bio.rs
@@ -277,7 +277,7 @@ impl BioWaiter {
     pub fn reqs(&self) -> impl Iterator<Item = Bio> {
         self.bios.iter().map(|bio_inner| Bio(bio_inner.clone()))
     }
-    
+
     /// Waits for the completion of all `Bio` requests.
     ///
     /// This method iterates through each `Bio` in the list, waiting for their

--- a/kernel/comps/block/src/bio.rs
+++ b/kernel/comps/block/src/bio.rs
@@ -273,6 +273,11 @@ impl BioWaiter {
         self.bios.append(&mut other.bios);
     }
 
+    /// Returns an iterator for the `Bio` requests associated with `self`.
+    pub fn reqs(&self) -> impl Iterator<Item = Bio> {
+        self.bios.iter().map(|bio_inner| Bio(bio_inner.clone()))
+    }
+    
     /// Waits for the completion of all `Bio` requests.
     ///
     /// This method iterates through each `Bio` in the list, waiting for their

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -1823,12 +1823,6 @@ impl InodeImpl {
 
 #[inherit_methods(from = "self.block_manager")]
 impl InodeImpl {
-    pub fn read_blocks_async(
-        &self,
-        bid: Ext2Bid,
-        nblocks: usize,
-        writer: &mut VmWriter,
-    ) -> Result<BioWaiter>;
     pub fn read_blocks(&self, bid: Ext2Bid, nblocks: usize, writer: &mut VmWriter) -> Result<()>;
     pub fn read_block_async(&self, bid: Ext2Bid, frame: &CachePage) -> Result<BioWaiter>;
     pub fn write_blocks_async(
@@ -1857,13 +1851,7 @@ struct InodeBlockManager {
 
 impl InodeBlockManager {
     /// Reads one or multiple blocks to the segment start from `bid` asynchronously.
-    pub fn read_blocks_async(
-        &self,
-        bid: Ext2Bid,
-        nblocks: usize,
-        writer: &mut VmWriter,
-    ) -> Result<BioWaiter> {
-        debug_assert!(nblocks * BLOCK_SIZE <= writer.avail());
+    fn read_blocks_async(&self, bid: Ext2Bid, nblocks: usize) -> Result<BioWaiter> {
         let mut bio_waiter = BioWaiter::new();
 
         for dev_range in DeviceRangeReader::new(self, bid..bid + nblocks as Ext2Bid)? {
@@ -1871,7 +1859,6 @@ impl InodeBlockManager {
             let range_nblocks = dev_range.len();
 
             let bio_segment = BioSegment::alloc(range_nblocks, BioDirection::FromDevice);
-            bio_segment.reader().unwrap().read_fallible(writer)?;
 
             let waiter = self.fs().read_blocks_async(start_bid, bio_segment)?;
             bio_waiter.concat(waiter);
@@ -1881,10 +1868,22 @@ impl InodeBlockManager {
     }
 
     pub fn read_blocks(&self, bid: Ext2Bid, nblocks: usize, writer: &mut VmWriter) -> Result<()> {
-        match self.read_blocks_async(bid, nblocks, writer)?.wait() {
-            Some(BioStatus::Complete) => Ok(()),
-            _ => return_errno!(Errno::EIO),
+        debug_assert!(nblocks * BLOCK_SIZE <= writer.avail());
+        let bio_waiter = self.read_blocks_async(bid, nblocks)?;
+        if Some(BioStatus::Complete) != bio_waiter.wait() {
+            return_errno!(Errno::EIO);
         }
+
+        for bio in bio_waiter.reqs() {
+            for segment in bio.segments() {
+                segment
+                    .reader()?
+                    .read_fallible(writer)
+                    .map_err(|(e, _)| Error::from(e))?;
+            }
+        }
+
+        Ok(())
     }
 
     fn start_segment_read(frame: &CachePage, dev_range: Range<u32>) -> (u32, BioSegment) {

--- a/test/apps/raid1/raid_smoke_test.c
+++ b/test/apps/raid1/raid_smoke_test.c
@@ -28,7 +28,8 @@ int main()
 	}
 
 	// Create the file and write the pattern to it
-	fd = open(RAID1_TEST_FILENAME, O_DIRECT | O_CREAT | O_WRONLY | O_TRUNC, 0666);
+	fd = open(RAID1_TEST_FILENAME, O_DIRECT | O_CREAT | O_WRONLY | O_TRUNC,
+		  0666);
 	if (fd < 0) {
 		fprintf(stderr, "[raid-test] Failed to create file '%s': %s\n",
 			RAID1_TEST_FILENAME, strerror(errno));

--- a/test/apps/raid1/raid_smoke_test.c
+++ b/test/apps/raid1/raid_smoke_test.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -26,7 +28,7 @@ int main()
 	}
 
 	// Create the file and write the pattern to it
-	fd = open(RAID1_TEST_FILENAME, O_CREAT | O_WRONLY | O_TRUNC, 0666);
+	fd = open(RAID1_TEST_FILENAME, O_DIRECT | O_CREAT | O_WRONLY | O_TRUNC, 0666);
 	if (fd < 0) {
 		fprintf(stderr, "[raid-test] Failed to create file '%s': %s\n",
 			RAID1_TEST_FILENAME, strerror(errno));
@@ -43,7 +45,7 @@ int main()
 	close(fd);
 
 	// Reopen the file for reading
-	fd = open(RAID1_TEST_FILENAME, O_RDONLY);
+	fd = open(RAID1_TEST_FILENAME, O_DIRECT | O_RDONLY);
 	if (fd < 0) {
 		fprintf(stderr,
 			"[raid-test] Failed to open file for reading: %s\n",


### PR DESCRIPTION
The previous ext2 filesystem doesn't correctly read data with the `O_DIRECT` flag added. This [issue](https://github.com/asterinas/asterinas/issues/2835) states the same thing. This PR migrates the upstream fix and updates the RAID1 smoke test to do direct IO. 