### PR TITLE
RAID1 Asynchronous Process Read

### DIFF
--- a/kernel/comps/block/src/bio.rs
+++ b/kernel/comps/block/src/bio.rs
@@ -884,6 +884,37 @@ impl From<BioDirection> for DmaDirection {
     }
 }
 
+/// Ensures a [`SubmittedBio`] is always completed — either explicitly
+/// via [`complete`](Self::complete) or with [`BioStatus::IoError`] on drop.
+///
+/// This is useful for non-blocking I/O paths where a parent BIO's completion
+/// must be guaranteed even if the child submission fails and is dropped.
+pub struct ParentGuard(Option<SubmittedBio>);
+
+impl ParentGuard {
+    /// Creates a new guard that will complete the given `SubmittedBio` with
+    /// [`BioStatus::IoError`] if not explicitly completed before being dropped.
+    pub fn new(parent: SubmittedBio) -> Self {
+        Self(Some(parent))
+    }
+
+    /// Completes the guarded `SubmittedBio` with the given status, consuming
+    /// the guard so the [`Drop`] impl becomes a no-op.
+    pub fn complete(mut self, status: BioStatus) {
+        if let Some(parent) = self.0.take() {
+            parent.complete(status);
+        }
+    }
+}
+
+impl Drop for ParentGuard {
+    fn drop(&mut self) {
+        if let Some(parent) = self.0.take() {
+            parent.complete(BioStatus::IoError);
+        }
+    }
+}
+
 /// Checks if the given offset is aligned to sector.
 pub fn is_sector_aligned(offset: usize) -> bool {
     offset % SECTOR_SIZE == 0

--- a/kernel/comps/block/src/request_queue.rs
+++ b/kernel/comps/block/src/request_queue.rs
@@ -163,6 +163,11 @@ impl BioRequest {
         self.bios.iter()
     }
 
+    /// Consumes the request and returns ownership of the `SubmittedBio`s.
+    pub fn into_bios(self) -> VecDeque<SubmittedBio> {
+        self.bios
+    }
+
     /// Returns the number of sectors of this request.
     pub fn num_sectors(&self) -> usize {
         (self.sid_range.end.to_raw() - self.sid_range.start.to_raw())

--- a/kernel/comps/raid/src/lib.rs
+++ b/kernel/comps/raid/src/lib.rs
@@ -170,6 +170,7 @@ impl Raid1Device {
     /// Each `SubmittedBio` in the merged `BioRequest` is assigned to device 0
     /// and submitted with `Bio::submit`. Completion of the parent is reported
     /// after the child finishes.
+    #[expect(dead_code)]
     #[cfg(baseline_asterinas)]
     fn process_read(&self, request: BioRequest) {
         for parent in request.bios() {
@@ -199,6 +200,7 @@ impl Raid1Device {
     /// Each `SubmittedBio` in the merged `BioRequest` is assigned to a read
     /// member (round-robin) and submitted with `Bio::submit` to overlap device
     /// I/O. Completion of the parent is reported after the child finishes.
+    #[expect(dead_code)]
     #[cfg(not(baseline_asterinas))]
     fn process_read(&self, request: BioRequest) {
         // Submit all children first to overlap device I/O.

--- a/kernel/comps/raid/src/lib.rs
+++ b/kernel/comps/raid/src/lib.rs
@@ -30,7 +30,9 @@ use core::{cmp, ops::Range};
 
 use aster_block::{
     BlockDevice, BlockDeviceMeta,
-    bio::{Bio, BioEnqueueError, BioSegment, BioStatus, BioType, BioWaiter, SubmittedBio},
+    bio::{
+        Bio, BioEnqueueError, BioSegment, BioStatus, BioType, BioWaiter, ParentGuard, SubmittedBio,
+    },
     id::Sid,
     request_queue::{BioRequest, BioRequestSingleQueue},
 };
@@ -39,30 +41,6 @@ use ostd::orpc::orpc_server;
 
 #[cfg(not(baseline_asterinas))]
 use crate::server_traits::SelectionPolicy;
-
-/// Ensures a parent [`SubmittedBio`] is always completed — either explicitly
-/// via [`complete`](Self::complete) or with [`BioStatus::IoError`] on drop.
-///
-/// This is used by the non-blocking read path: the guard is moved into the
-/// child BIO's completion callback. If the child completes normally, the
-/// callback calls [`complete`](Self::complete). If submission fails and the
-/// child is dropped, the guard's [`Drop`] impl completes the parent with an
-/// error so the filesystem thread is never left waiting.
-struct ParentGuard(Option<SubmittedBio>);
-impl ParentGuard {
-    fn complete(mut self, status: BioStatus) {
-        if let Some(parent) = self.0.take() {
-            parent.complete(status);
-        }
-    }
-}
-impl Drop for ParentGuard {
-    fn drop(&mut self) {
-        if let Some(parent) = self.0.take() {
-            parent.complete(BioStatus::IoError);
-        }
-    }
-}
 
 /// A RAID-1 block device that mirrors I/O to multiple member devices.
 #[cfg(baseline_asterinas)]
@@ -269,7 +247,7 @@ impl Raid1Device {
             
             let start_sid = parent.sid_range().start;
             let segments = parent.segments().to_vec();
-            let guard = ParentGuard(Some(parent));
+            let guard = ParentGuard::new(parent);
             let child = Bio::new_with_closure(
                 BioType::Read,
                 start_sid,

--- a/kernel/comps/raid/src/lib.rs
+++ b/kernel/comps/raid/src/lib.rs
@@ -165,10 +165,10 @@ impl Raid1Device {
     }
 
     /// Processes read requests synchronously.
-    /// Asterinas Baseline Version, i.e., not selecting read member, just use device 0. 
+    /// Asterinas Baseline Version, i.e., not selecting read member, just use device 0.
     ///
     /// Each `SubmittedBio` in the merged `BioRequest` is assigned to device 0
-    /// and submitted with `Bio::submit`. Completion of the parent is reported 
+    /// and submitted with `Bio::submit`. Completion of the parent is reported
     /// after the child finishes.
     #[cfg(baseline_asterinas)]
     fn process_read(&self, request: BioRequest) {
@@ -195,7 +195,7 @@ impl Raid1Device {
 
     /// Processes read requests synchronously.
     /// ORPC Version, i.e., do actual device selection
-    /// 
+    ///
     /// Each `SubmittedBio` in the merged `BioRequest` is assigned to a read
     /// member (round-robin) and submitted with `Bio::submit` to overlap device
     /// I/O. Completion of the parent is reported after the child finishes.
@@ -232,19 +232,19 @@ impl Raid1Device {
         }
     }
 
-    /// Processes read requests asynchronously. 
-    /// 
+    /// Processes read requests asynchronously.
+    ///
     /// Each `SubmittedBio` in the merged `BioRequest` is assigned to a read
     /// member by the selection policy (device 0 if asterinas baseline) and submitted with `Bio::submit` to overlap device
     /// I/O. Completion of the parent is reported after the child finishes.    
     fn process_read_async(&self, request: BioRequest) {
-        for parent in request.into_bios() {;
+        for parent in request.into_bios() {
             #[cfg(not(baseline_asterinas))]
             let member = self.selection_policy.select_block_device().unwrap();
-            
+
             #[cfg(baseline_asterinas)]
             let member = self.members[0].clone();
-            
+
             let start_sid = parent.sid_range().start;
             let segments = parent.segments().to_vec();
             let guard = ParentGuard::new(parent);

--- a/kernel/comps/raid/src/lib.rs
+++ b/kernel/comps/raid/src/lib.rs
@@ -262,7 +262,7 @@ impl Raid1Device {
     /// I/O. Completion of the parent is reported after the child finishes.
     #[cfg(baseline_asterinas)]
     fn process_read_async(&self, request: BioRequest) {
-        for parent in request.into_bios() {;
+        for parent in request.into_bios() {
             let member = self.devices[0].clone();
             let start_sid = parent.sid_range().start;
             let segments = parent.segments().to_vec();

--- a/kernel/comps/raid/src/lib.rs
+++ b/kernel/comps/raid/src/lib.rs
@@ -169,7 +169,7 @@ impl Raid1Device {
     /// any `BlockDevice` and applies RAID semantics underneath.
     fn process_request(&self, request: BioRequest) {
         match request.type_() {
-            BioType::Read => self.process_read(request),
+            BioType::Read => self.process_read_async(request),
             BioType::Write => self.process_write(request),
             BioType::Flush => self.process_flush(request),
             BioType::Discard => self.process_discard(request),
@@ -221,7 +221,7 @@ impl Raid1Device {
     /// Each `SubmittedBio` in the merged `BioRequest` is assigned to a read
     /// member (round-robin) and submitted with `Bio::submit` to overlap device
     /// I/O. Completion of the parent is reported after the child finishes.
-    #[cfg(sbaseline_asterinas)]
+    #[cfg(not(baseline_asterinas))]
     fn process_read(&self, request: BioRequest) {
         // Submit all children first to overlap device I/O.
         let mut pending: alloc::vec::Vec<(&SubmittedBio, BioWaiter)> = alloc::vec::Vec::new();

--- a/kernel/comps/raid/src/lib.rs
+++ b/kernel/comps/raid/src/lib.rs
@@ -254,41 +254,19 @@ impl Raid1Device {
         }
     }
 
-    /// Processes read requests asynchronously.
-    /// Asterinas Baseline Version, i.e., not selecting read member, just use device 0. 
-    ///
-    /// Each `SubmittedBio` in the merged `BioRequest` is assigned to a read
-    /// member device 0 and submitted with `Bio::submit` to overlap device
-    /// I/O. Completion of the parent is reported after the child finishes.
-    #[cfg(baseline_asterinas)]
-    fn process_read_async(&self, request: BioRequest) {
-        for parent in request.into_bios() {
-            let member = self.members[0].clone();
-            let start_sid = parent.sid_range().start;
-            let segments = parent.segments().to_vec();
-            let guard = ParentGuard(Some(parent));
-            let child = Bio::new_with_closure(
-                BioType::Read,
-                start_sid,
-                segments,
-                move |child_bio: &SubmittedBio| {
-                    guard.complete(child_bio.status());
-                },
-            );
-            let _ = child.submit(&*member);
-        }
-    }
-
     /// Processes read requests asynchronously. 
-    /// ORPC Version, i.e., do actual device selection
     /// 
     /// Each `SubmittedBio` in the merged `BioRequest` is assigned to a read
-    /// member by the selection policy and submitted with `Bio::submit` to overlap device
-    /// I/O. Completion of the parent is reported after the child finishes.
-    #[cfg(not(baseline_asterinas))]
+    /// member by the selection policy (device 0 if asterinas baseline) and submitted with `Bio::submit` to overlap device
+    /// I/O. Completion of the parent is reported after the child finishes.    
     fn process_read_async(&self, request: BioRequest) {
         for parent in request.into_bios() {;
+            #[cfg(not(baseline_asterinas))]
             let member = self.selection_policy.select_block_device().unwrap();
+            
+            #[cfg(baseline_asterinas)]
+            let member = self.members[0].clone();
+            
             let start_sid = parent.sid_range().start;
             let segments = parent.segments().to_vec();
             let guard = ParentGuard(Some(parent));

--- a/kernel/comps/raid/src/lib.rs
+++ b/kernel/comps/raid/src/lib.rs
@@ -263,7 +263,7 @@ impl Raid1Device {
     #[cfg(baseline_asterinas)]
     fn process_read_async(&self, request: BioRequest) {
         for parent in request.into_bios() {
-            let member = self.devices[0].clone();
+            let member = self.members[0].clone();
             let start_sid = parent.sid_range().start;
             let segments = parent.segments().to_vec();
             let guard = ParentGuard(Some(parent));

--- a/kernel/comps/raid/src/lib.rs
+++ b/kernel/comps/raid/src/lib.rs
@@ -40,6 +40,30 @@ use ostd::orpc::orpc_server;
 #[cfg(not(baseline_asterinas))]
 use crate::server_traits::SelectionPolicy;
 
+/// Ensures a parent [`SubmittedBio`] is always completed — either explicitly
+/// via [`complete`](Self::complete) or with [`BioStatus::IoError`] on drop.
+///
+/// This is used by the non-blocking read path: the guard is moved into the
+/// child BIO's completion callback. If the child completes normally, the
+/// callback calls [`complete`](Self::complete). If submission fails and the
+/// child is dropped, the guard's [`Drop`] impl completes the parent with an
+/// error so the filesystem thread is never left waiting.
+struct ParentGuard(Option<SubmittedBio>);
+impl ParentGuard {
+    fn complete(mut self, status: BioStatus) {
+        if let Some(parent) = self.0.take() {
+            parent.complete(status);
+        }
+    }
+}
+impl Drop for ParentGuard {
+    fn drop(&mut self) {
+        if let Some(parent) = self.0.take() {
+            parent.complete(BioStatus::IoError);
+        }
+    }
+}
+
 /// A RAID-1 block device that mirrors I/O to multiple member devices.
 #[cfg(baseline_asterinas)]
 #[derive(Debug)]
@@ -162,11 +186,12 @@ impl Raid1Device {
         }
     }
 
-    /// Processes read requests asynchronously.
+    /// Processes read requests synchronously.
+    /// Asterinas Baseline Version, i.e., not selecting read member, just use device 0. 
     ///
-    /// Each `SubmittedBio` in the merged `BioRequest` is assigned to a read
-    /// member (round-robin) and submitted with `Bio::submit` to overlap device
-    /// I/O. Completion of the parent is reported after the child finishes.
+    /// Each `SubmittedBio` in the merged `BioRequest` is assigned to device 0
+    /// and submitted with `Bio::submit`. Completion of the parent is reported 
+    /// after the child finishes.
     #[cfg(baseline_asterinas)]
     fn process_read(&self, request: BioRequest) {
         for parent in request.bios() {
@@ -190,14 +215,14 @@ impl Raid1Device {
         }
     }
 
-    /// Processes read requests asynchronously.
-    ///
+    /// Processes read requests synchronously.
+    /// ORPC Version, i.e., do actual device selection
+    /// 
     /// Each `SubmittedBio` in the merged `BioRequest` is assigned to a read
     /// member (round-robin) and submitted with `Bio::submit` to overlap device
     /// I/O. Completion of the parent is reported after the child finishes.
-    #[cfg(not(baseline_asterinas))]
+    #[cfg(sbaseline_asterinas)]
     fn process_read(&self, request: BioRequest) {
-        // TODO(yingqi): Implement asynchronous read with policy selector.
         // Submit all children first to overlap device I/O.
         let mut pending: alloc::vec::Vec<(&SubmittedBio, BioWaiter)> = alloc::vec::Vec::new();
 
@@ -226,6 +251,56 @@ impl Raid1Device {
             };
             // Report the completion status to the upper layer.
             parent.complete(status);
+        }
+    }
+
+    /// Processes read requests asynchronously.
+    /// Asterinas Baseline Version, i.e., not selecting read member, just use device 0. 
+    ///
+    /// Each `SubmittedBio` in the merged `BioRequest` is assigned to a read
+    /// member device 0 and submitted with `Bio::submit` to overlap device
+    /// I/O. Completion of the parent is reported after the child finishes.
+    #[cfg(baseline_asterinas)]
+    fn process_read_async(&self, request: BioRequest) {
+        for parent in request.into_bios() {;
+            let member = self.devices[0].clone();
+            let start_sid = parent.sid_range().start;
+            let segments = parent.segments().to_vec();
+            let guard = ParentGuard(Some(parent));
+            let child = Bio::new_with_closure(
+                BioType::Read,
+                start_sid,
+                segments,
+                move |child_bio: &SubmittedBio| {
+                    guard.complete(child_bio.status());
+                },
+            );
+            let _ = child.submit(&*member);
+        }
+    }
+
+    /// Processes read requests asynchronously. 
+    /// ORPC Version, i.e., do actual device selection
+    /// 
+    /// Each `SubmittedBio` in the merged `BioRequest` is assigned to a read
+    /// member by the selection policy and submitted with `Bio::submit` to overlap device
+    /// I/O. Completion of the parent is reported after the child finishes.
+    #[cfg(not(baseline_asterinas))]
+    fn process_read_async(&self, request: BioRequest) {
+        for parent in request.into_bios() {;
+            let member = self.selection_policy.select_block_device().unwrap();
+            let start_sid = parent.sid_range().start;
+            let segments = parent.segments().to_vec();
+            let guard = ParentGuard(Some(parent));
+            let child = Bio::new_with_closure(
+                BioType::Read,
+                start_sid,
+                segments,
+                move |child_bio: &SubmittedBio| {
+                    guard.complete(child_bio.status());
+                },
+            );
+            let _ = child.submit(&*member);
         }
     }
 

--- a/test/apps/raid1/raid_smoke_test.c
+++ b/test/apps/raid1/raid_smoke_test.c
@@ -20,8 +20,8 @@ int main()
 	int fd;
 	ssize_t n;
 	unsigned char *pattern, *read_back;
-	posix_memalign((void**)&pattern, 4096, RAID1_TEST_BLOCK_SIZE);
-	posix_memalign((void**)&read_back, 4096, RAID1_TEST_BLOCK_SIZE);
+	posix_memalign((void **)&pattern, 4096, RAID1_TEST_BLOCK_SIZE);
+	posix_memalign((void **)&read_back, 4096, RAID1_TEST_BLOCK_SIZE);
 	int i, ret = 0;
 
 	// Fill pattern buffer with known values
@@ -73,8 +73,8 @@ int main()
 
 	// Print the read content
 	printf("first 8 bytes read: %02x %02x %02x %02x %02x %02x %02x %02x\n",
-    read_back[0], read_back[1], read_back[2], read_back[3],
-    read_back[4], read_back[5], read_back[6], read_back[7]);
+	       read_back[0], read_back[1], read_back[2], read_back[3],
+	       read_back[4], read_back[5], read_back[6], read_back[7]);
 	printf("expected:           00 01 02 03 04 05 06 07\n");
 
 	// Compare written and read data

--- a/test/apps/raid1/raid_smoke_test.c
+++ b/test/apps/raid1/raid_smoke_test.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+#include <sys/stat.h>
 
 // Define the file size for the test (e.g., one block = 4096 bytes)
 #define RAID1_TEST_BLOCK_SIZE 8192

--- a/test/apps/raid1/raid_smoke_test.c
+++ b/test/apps/raid1/raid_smoke_test.c
@@ -10,7 +10,7 @@
 #include <errno.h>
 
 // Define the file size for the test (e.g., one block = 4096 bytes)
-#define RAID1_TEST_BLOCK_SIZE 4096
+#define RAID1_TEST_BLOCK_SIZE 8192
 #define RAID1_TEST_FILENAME "/raid1/raid_smoke_file"
 
 // Returns 0 on success, -1 on error
@@ -18,8 +18,9 @@ int main()
 {
 	int fd;
 	ssize_t n;
-	unsigned char pattern[RAID1_TEST_BLOCK_SIZE];
-	unsigned char read_back[RAID1_TEST_BLOCK_SIZE];
+	unsigned char *pattern, *read_back;
+	posix_memalign((void**)&pattern, 4096, RAID1_TEST_BLOCK_SIZE);
+	posix_memalign((void**)&read_back, 4096, RAID1_TEST_BLOCK_SIZE);
 	int i, ret = 0;
 
 	// Fill pattern buffer with known values
@@ -43,6 +44,11 @@ int main()
 		close(fd);
 		return -1;
 	}
+	fsync(fd);
+	// After write and fsync, before close:
+	struct stat st;
+	fstat(fd, &st);
+	printf("file size after O_DIRECT write: %ld\n", (long)st.st_size);
 	close(fd);
 
 	// Reopen the file for reading
@@ -54,7 +60,7 @@ int main()
 		return -1;
 	}
 
-	memset(read_back, 0, sizeof(read_back));
+	memset(read_back, 0, RAID1_TEST_BLOCK_SIZE);
 	n = read(fd, read_back, RAID1_TEST_BLOCK_SIZE);
 	if (n != RAID1_TEST_BLOCK_SIZE) {
 		fprintf(stderr, "[raid-test] Failed to read test data: %s\n",
@@ -63,6 +69,12 @@ int main()
 		return -1;
 	}
 	close(fd);
+
+	// Print the read content
+	printf("first 8 bytes read: %02x %02x %02x %02x %02x %02x %02x %02x\n",
+    read_back[0], read_back[1], read_back[2], read_back[3],
+    read_back[4], read_back[5], read_back[6], read_back[7]);
+	printf("expected:           00 01 02 03 04 05 06 07\n");
 
 	// Compare written and read data
 	if (memcmp(pattern, read_back, RAID1_TEST_BLOCK_SIZE) == 0) {
@@ -74,8 +86,16 @@ int main()
 		ret = -1;
 	}
 
+	// dump all the data
+	printf("full read data:\n");
+	for (i = 0; i < RAID1_TEST_BLOCK_SIZE; i++) {
+		printf("%02x ", read_back[i]);
+		if ((i + 1) % 16 == 0)
+			printf("\n");
+	}
+
 	// Optionally, remove test file
-	unlink(RAID1_TEST_FILENAME);
+	// unlink(RAID1_TEST_FILENAME);
 
 	return ret;
 }


### PR DESCRIPTION
Added `process_read_async` function, which is the asynchronous version of the `process_read` function. The `process_read_async` iterates through the list of `SubmittedBio` and passes them to the VirtIO level by wrapping them together with a callback closure using the `Bio::new_with_closure` function. Then it returns without waiting for the Bio to complete. The callback will be executed automatically once the Bio is completed, reporting to the FS layer for the completion message.

Also, updated the RAID1 smoke test to be a bit more complicated. 

Note:
1. The `ParentGuard` is AI-generated, used to make sure the FS can move on, no matter if the Bio completes successfully or fails. 
2. We probably need to redefine the actual baseline for RAID1. Currently, the `asterinas_baseline` is implemented as just selecting device 0. However, I think a round robin is a better baseline, because it always selects device 0, making it not RAID1 at all. We can easily implement a non-0ORPC round robin with a built-in atomic cursor. We can update this in a later PR. 
3. Does `process_write` need to be asynchronous as well? Will it cause correctness or synchronization issues if we make it `async`? If we do, we can do that in a later PR since there will be some effort to maintain the correct read/write order if they are all async. 