### PR TITLE
CBOR based data capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ aster-nix-profile-*.svg
 
 # editor configuration
 .vscode
+
+# Python files
+__pycache__

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,12 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "array-init"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
-
-[[package]]
 name = "aster-bigtcp"
 version = "0.1.0"
 dependencies = [
@@ -361,7 +355,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -384,29 +378,6 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
-
-[[package]]
-name = "binary_serde"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b2fe974c561ed04fb89673dd221bed36fc4794b71ca6ae96ffe19949045686"
-dependencies = [
- "array-init",
- "binary_serde_macros",
- "recursive_array",
- "thiserror-no-std",
-]
-
-[[package]]
-name = "binary_serde_macros"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4790b8dbcfa9d3adf2020ebf5fd36c6bc89a77d434131615ea349bc9620e8831"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
 
 [[package]]
 name = "bit_field"
@@ -467,7 +438,7 @@ checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -661,7 +632,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -814,7 +785,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -986,7 +957,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1179,10 +1150,12 @@ version = "0.1.0"
 dependencies = [
  "aster-block",
  "aster-logger",
- "binary_serde",
  "component",
  "log",
+ "minicbor",
+ "minicbor-serde",
  "ostd",
+ "serde",
  "snafu",
 ]
 
@@ -1199,6 +1172,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minicbor"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70eae6d4f18f7d76877fe7b13f0bc21f7c2b7239d2041c338335f7b388d0dd7"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "294f0a0c161c510e9746adf546b8b044fbb0b00677d7dfc9a2452f9fdf63439b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "minicbor-serde"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80047f75e28e3b38f6ab2ec3c2c7669f6b411fa6f8424e1a90a3fd784b19a3f4"
+dependencies = [
+ "minicbor",
+ "serde",
 ]
 
 [[package]]
@@ -1354,6 +1357,7 @@ dependencies = [
  "ostd-test",
  "riscv",
  "sbi-rt",
+ "serde",
  "slotmap",
  "smallvec",
  "snafu",
@@ -1374,7 +1378,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rand",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1480,14 +1484,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1529,7 +1533,7 @@ checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1540,9 +1544,9 @@ checksum = "8bb0fd6580eeed0103c054e3fba2c2618ff476943762f28a645b63b8692b21c9"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1591,12 +1595,6 @@ checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
 ]
-
-[[package]]
-name = "recursive_array"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69bad83913c3b39011ad9d43b7ac0cae139cec5d7e7288fbea5bb4b4e3cc78f6"
 
 [[package]]
 name = "riscv"
@@ -1673,7 +1671,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1732,7 +1730,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1781,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1831,27 +1829,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "thiserror-impl-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "thiserror-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
-dependencies = [
- "thiserror-impl-no-std",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1979,7 +1957,7 @@ checksum = "c19ee3a01d435eda42cb9931269b349d28a1762f91ddf01c68d276f74b957cc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2128,5 +2106,5 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.117",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
  "paste",
  "rand",
  "riscv",
+ "serde",
  "snafu",
  "spin",
  "takeable",

--- a/OSDK.toml
+++ b/OSDK.toml
@@ -64,6 +64,8 @@ qemu.args = """\
     -drive if=none,format=raw,id=x1,file=./test/build/exfat.img \
     -drive if=none,format=raw,id=r0,file=./test/build/raid1_0.img \
     -drive if=none,format=raw,id=r1,file=./test/build/raid1_1.img \
+    -drive if=none,format=raw,id=d0,file=./test/build/capture.img \
+    -drive if=none,format=raw,id=d1,file=./test/build/capture_legacy.img \
     -device virtio-blk-device,drive=x0 \
     -device virtio-keyboard-device \
     -device virtio-serial-device \

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -41,6 +41,7 @@ intrusive-collections = "0.9.5"
 paste = "1.0"
 time = { version = "0.3", default-features = false, features = ["alloc"] }
 snafu = { workspace = true }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"]}
 
 # parse elf file
 xmas-elf = "0.10.0"

--- a/kernel/comps/mariposa_data_capture/Cargo.toml
+++ b/kernel/comps/mariposa_data_capture/Cargo.toml
@@ -15,7 +15,7 @@ minicbor = { version = "2.2", default-features = false, features = ["derive", "a
 minicbor-serde = { version = "0.6", default-features = false }
 
 log = "0.4"
-snafu = { workspace = true } 
+snafu = { workspace = true }
 
 [lints]
 workspace = true

--- a/kernel/comps/mariposa_data_capture/Cargo.toml
+++ b/kernel/comps/mariposa_data_capture/Cargo.toml
@@ -10,9 +10,12 @@ component = { path = "../../libs/comp-sys/component" }
 aster-logger = { path = "../logger" }
 aster-block = { path = "../block" }
 ostd = { path = "../../../ostd" }
-binary_serde = "1.0.25"
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"]}
+minicbor = { version = "2.2", default-features = false, features = ["derive", "alloc"] }
+minicbor-serde = { version = "0.6", default-features = false }
+
 log = "0.4"
-snafu = { workspace = true }
+snafu = { workspace = true } 
 
 [lints]
 workspace = true

--- a/kernel/comps/mariposa_data_capture/python/decode_mariposa_data.py
+++ b/kernel/comps/mariposa_data_capture/python/decode_mariposa_data.py
@@ -18,30 +18,14 @@ stdout instead of writing any files.
 
 import argparse
 import json
+import logging
 import re
-import sys
 from pathlib import Path
-
-import cbor2
 
 from mariposa_data_reader import DataCaptureDevice
 
 
-class _CborEncoder(json.JSONEncoder):
-    """Extend the default JSON encoder to handle types cbor2 may return."""
-
-    def default(self, o):
-        if isinstance(o, bytes):
-            return {"$bytes": o.hex()}
-        if isinstance(o, set) or isinstance(o, frozenset):
-            return list(o)
-        if isinstance(o, cbor2.CBORTag):
-            return o.value
-        return super().default(o)
-
-
-def _to_json(record) -> str:
-    return json.dumps(record, cls=_CborEncoder)
+logger = logging.getLogger(__name__)
 
 
 def _output_name(capture_path: str) -> str:
@@ -56,7 +40,7 @@ def _preview(device: DataCaptureDevice, n: int):
         try:
             type_name = capture_file.type_name
         except Exception as exc:
-            print(f"[{path}] warning: could not read header: {exc}", file=sys.stderr)
+            logger.error(f"[{path}] warning: could not read header: {exc}")
             type_name = "<unknown>"
 
         print(f"=== {path} (type: {type_name})")
@@ -64,7 +48,10 @@ def _preview(device: DataCaptureDevice, n: int):
             if i >= n:
                 print(f"  ... (showing first {n} records)")
                 break
-            print(f"  {_to_json(record)}")
+            try:
+                print(f"  {json.dumps(record)}")
+            except (ValueError, TypeError) as e:
+                logger.error(f"{e}")
         print()
 
 
@@ -75,9 +62,15 @@ def _dump(device: DataCaptureDevice, output_dir: Path):
         count = 0
         with open(out_path, "w") as out:
             for record in capture_file:
-                out.write(_to_json(record))
-                out.write("\n")
-                count += 1
+                try:
+                    out.write(json.dumps(record))
+                    out.write("\n")
+                    count += 1
+                except (ValueError, TypeError) as e:
+                    logger.error(
+                        f"Failed to write record {count} as JSON: {record}\n  {e}\n"
+                        "  (If this is the last record, the stream may have been truncated, e.g., by failing to flush or running out of space.)"
+                    )
         print(
             f"Wrote {count} records (of type {capture_file.type_name}) to {out_path}."
         )
@@ -99,7 +92,8 @@ def main():
         "-p",
         type=int,
         metavar="N",
-        help="Print the first N records of each file to stdout instead of writing files.",
+        help="Print the first N records of each file to stdout instead of writing files. "
+        "This intensionally permits more errors than full decoding.",
     )
     args = parser.parse_args()
 

--- a/kernel/comps/mariposa_data_capture/python/decode_mariposa_data.py
+++ b/kernel/comps/mariposa_data_capture/python/decode_mariposa_data.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+Decode a Mariposa data-capture device image and write one JSONL file per
+capture file in the image.
+
+Usage:
+    dump_capture.py <device_file> [--output-dir DIR] [--preview N]
+
+Each captured file produces a JSONL output file named:
+    <path>.jsonl
+where <path> has path-separator characters replaced with underscores.
+
+With --preview, the first N records of every captured file are printed to
+stdout instead of writing any files.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import cbor2
+
+from mariposa_data_reader import DataCaptureDevice
+
+
+class _CborEncoder(json.JSONEncoder):
+    """Extend the default JSON encoder to handle types cbor2 may return."""
+
+    def default(self, o):
+        if isinstance(o, bytes):
+            return {"$bytes": o.hex()}
+        if isinstance(o, set) or isinstance(o, frozenset):
+            return list(o)
+        if isinstance(o, cbor2.CBORTag):
+            return o.value
+        return super().default(o)
+
+
+def _to_json(record) -> str:
+    return json.dumps(record, cls=_CborEncoder)
+
+
+def _output_name(capture_path: str) -> str:
+    """Build a safe filename from the capture file's path."""
+    safe_path = re.sub(r"[^A-Za-z0-9_\-]", "_", capture_path)
+    return f"{safe_path}.jsonl"
+
+
+def _preview(device: DataCaptureDevice, n: int):
+    for capture_file in device:
+        path = capture_file.path
+        try:
+            type_name = capture_file.type_name
+        except Exception as exc:
+            print(f"[{path}] warning: could not read header: {exc}", file=sys.stderr)
+            type_name = "<unknown>"
+
+        print(f"=== {path} (type: {type_name})")
+        for i, record in enumerate(capture_file):
+            if i >= n:
+                print(f"  ... (showing first {n} records)")
+                break
+            print(f"  {_to_json(record)}")
+        print()
+
+
+def _dump(device: DataCaptureDevice, output_dir: Path):
+    for capture_file in device:
+        path = capture_file.path
+        out_path = output_dir / _output_name(path)
+        count = 0
+        with open(out_path, "w") as out:
+            for record in capture_file:
+                out.write(_to_json(record))
+                out.write("\n")
+                count += 1
+        print(
+            f"Wrote {count} records (of type {capture_file.type_name}) to {out_path}."
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Decode a Mariposa data-capture device image into JSONL."
+    )
+    parser.add_argument("device", help="Path to the device image file.")
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        metavar="DIR",
+        help="Directory to write JSONL files into (default: current directory).",
+    )
+    parser.add_argument(
+        "--preview",
+        "-p",
+        type=int,
+        metavar="N",
+        help="Print the first N records of each file to stdout instead of writing files.",
+    )
+    args = parser.parse_args()
+
+    device = DataCaptureDevice(args.device)
+
+    if args.preview is not None:
+        _preview(device, args.preview)
+    else:
+        _dump(device, Path(args.output_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/kernel/comps/mariposa_data_capture/python/decode_mariposa_data.py
+++ b/kernel/comps/mariposa_data_capture/python/decode_mariposa_data.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MPL-2.0
 
+# /// script
+# dependencies = [
+#   "cbor2==5.9"
+# ]
+# ///
+
 """
 Decode a Mariposa data-capture device image and write one JSONL file per
 capture file in the image.

--- a/kernel/comps/mariposa_data_capture/python/mariposa_data_reader.py
+++ b/kernel/comps/mariposa_data_capture/python/mariposa_data_reader.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+A library to parse data written using the `mariposa_data_capture` crate.
+
+This reads the data using the headers in the format defined in the crate and then decodes and
+returns the records directly.
+"""
+
+from pathlib import Path
+
+import cbor2
+
+BLOCK_SIZE = 4096
+DIRECTORY_BLOCKS = 1
+DIRECTORY_SIZE = DIRECTORY_BLOCKS * BLOCK_SIZE
+
+MAGIC = b"MARIPOSALDOSDATA\x00"
+
+
+class InvalidHeaderError(Exception):
+    pass
+
+
+def _decode_cbor_values(decoder: cbor2.CBORDecoder, end_pos: int):
+    """
+    Yield decoded CBOR values from *decoder* until *end_pos* is reached in the underlying stream or
+    a 0xff (the CBOR "break" command) is encountered after a message.
+    """
+    fp = decoder.fp
+    while fp.tell() < end_pos:
+        peek_pos = fp.tell()
+        peek = fp.read(1)
+        fp.seek(peek_pos)
+        if peek == b"\xff":
+            break
+        yield decoder.decode()
+
+
+class DataCaptureDevice:
+    """
+    A whole device containing data captured in Mariposa using the `mariposa_data_capture` crate.
+    """
+
+    def __init__(self, filename: Path):
+        self._filename = filename
+        with open(self._filename, "rb") as f:
+            decoder = cbor2.CBORDecoder(f)
+            self._file_records = list(_decode_cbor_values(decoder, DIRECTORY_SIZE))
+
+    def __len__(self):
+        return len(self._file_records)
+
+    def __iter__(self):
+        """Iterate over all the files on the device."""
+        for record in self._file_records:
+            yield DataCaptureFile(self._filename, record)
+
+    def __getitem__(self, index):
+        """Get a specific file by its index."""
+        return DataCaptureFile(self._filename, self._file_records[index])
+
+
+class DataCaptureFile:
+    """
+    A single capture file in a DataCaptureDevice.
+    """
+
+    def __init__(self, device_filename: Path, record: dict):
+        self._device_filename = device_filename
+        self._offset = record["offset"]
+        self._length = record["length"]
+        self._path = record["path"]
+        self._header = None
+
+    def _new_decoder(self, f) -> cbor2.CBORDecoder:
+        """
+        Construct a new decoder on this file. It starts at the beginning of the file header.
+        """
+        f.seek(self._offset)
+        magic = f.read(len(MAGIC))
+        if magic != MAGIC:
+            raise InvalidHeaderError(
+                f"Expected file magic at offset {self._offset:#x}, got {magic!r}. "
+                f"This generally means the data capture file was not sync()'ed."
+            )
+        return cbor2.CBORDecoder(f)
+
+    def _get_header(self):
+        """
+        Get the header of this file.
+        """
+        if self._header is None:
+            with open(self._device_filename, "rb") as f:
+                decoder = self._new_decoder(f)
+                header = decoder.decode()
+            self._header = header
+        return self._header
+
+    @property
+    def path(self) -> str:
+        """The path provided when creating the file in the kernel capture code."""
+        return self._path
+
+    @property
+    def type_name(self) -> str:
+        """The Rust type which was serialized into the file."""
+        return self._get_header()["type_name"]
+
+    def __iter__(self):
+        """
+        Iterate over the records in the capture file.
+
+        This stops when either the file is empty or the decoder encounters 0xff instead of a record.
+        This is the CBOR2 "break" command, so it can never appear as the start of a correct record.
+        """
+        end_offset = self._offset + self._length
+        with open(self._device_filename, "rb") as f:
+            decoder = self._new_decoder(f)
+            decoder.decode()  # skip the header
+            yield from _decode_cbor_values(decoder, end_offset)

--- a/kernel/comps/mariposa_data_capture/python/mariposa_data_reader.py
+++ b/kernel/comps/mariposa_data_capture/python/mariposa_data_reader.py
@@ -3,38 +3,61 @@
 """
 A library to parse data written using the `mariposa_data_capture` crate.
 
-This reads the data using the headers in the format defined in the crate and then decodes and
-returns the records directly.
+This reads the data using the headers in the format defined in the crate and then decodes the
+records.
 """
 
+import logging
 from pathlib import Path
 
 import cbor2
 
+# This must match the DIRECTORY_BLOCKS constant in `data_capture_device.rs`
 BLOCK_SIZE = 4096
 DIRECTORY_BLOCKS = 1
 DIRECTORY_SIZE = DIRECTORY_BLOCKS * BLOCK_SIZE
 
+# This must match the MAGIC constant in `data_buffering.rs`
 MAGIC = b"MARIPOSALDOSDATA\x00"
 
+logger = logging.getLogger(__name__)
 
-class InvalidHeaderError(Exception):
+
+class InvalidHeaderError(ValueError):
     pass
 
 
 def _decode_cbor_values(decoder: cbor2.CBORDecoder, end_pos: int):
     """
-    Yield decoded CBOR values from *decoder* until *end_pos* is reached in the underlying stream or
-    a 0xff (the CBOR "break" command) is encountered after a message.
+    Yield decoded CBOR values from `decoder` until file offset `end_pos`, a `0xff` (the CBOR "break"
+    command) is encountered after a message, or an invalid record is encountered.
     """
     fp = decoder.fp
-    while fp.tell() < end_pos:
+    i = 0
+    # Breaks when the stream is over as defined above.
+    while True:
         peek_pos = fp.tell()
         peek = fp.read(1)
         fp.seek(peek_pos)
         if peek == b"\xff":
             break
-        yield decoder.decode()
+        try:
+            record = decoder.decode()
+            # Check if we have overrun the file here, since we can't know the record length before
+            # reading it.
+            if fp.tell() < end_pos:
+                yield record
+            else:
+                break
+        except cbor2.CBORDecodeValueError as e:
+            # Only print an error if the record completed before the end of the file.
+            if fp.tell() < end_pos:
+                logger.error(
+                    f"CBOR decoding failed at element {i} (at offset {peek_pos}), assuming end of event stream: {e}\n"
+                    "(The stream may have been truncated, e.g., by failing to flush or running out of space.)"
+                )
+            break
+        i += 1
 
 
 class DataCaptureDevice:
@@ -63,25 +86,31 @@ class DataCaptureDevice:
 
 class DataCaptureFile:
     """
-    A single capture file in a DataCaptureDevice.
+    A single capture file in a `DataCaptureDevice`.
     """
 
     def __init__(self, device_filename: Path, record: dict):
         self._device_filename = device_filename
-        self._offset = record["offset"]
-        self._length = record["length"]
-        self._path = record["path"]
+        try:
+            if not isinstance(record, dict):
+                raise KeyError()
+            self._offset = record["offset"]
+            self._length = record["length"]
+            self._path = record["path"]
+        except KeyError:
+            raise ValueError(f"Invalid file record: {record}")
         self._header = None
 
     def _new_decoder(self, f) -> cbor2.CBORDecoder:
         """
-        Construct a new decoder on this file. It starts at the beginning of the file header.
+        Construct a new decoder on this file. It starts at the beginning of the file header;
+        immediately after the magic number.
         """
         f.seek(self._offset)
         magic = f.read(len(MAGIC))
         if magic != MAGIC:
             raise InvalidHeaderError(
-                f"Expected file magic at offset {self._offset:#x}, got {magic!r}. "
+                f"Expected file magic at offset {self._offset}, got {magic!r}. "
                 f"This generally means the data capture file was not sync()'ed."
             )
         return cbor2.CBORDecoder(f)
@@ -111,11 +140,15 @@ class DataCaptureFile:
         """
         Iterate over the records in the capture file.
 
-        This stops when either the file is empty or the decoder encounters 0xff instead of a record.
-        This is the CBOR2 "break" command, so it can never appear as the start of a correct record.
+        The end is either when the file length is reached, the decoder encounters `0xff` instead of
+        a record, or an invalid CBOR record is found. `0xff` is the CBOR "break" command, so it can
+        never appear as the start of a correct record. An invalid record is treated as a terminator,
+        since a truncated file should still be readable. Note that a truncated file can produce an
+        oddly formatted record (or records), if the following bytes happen to be valid CBOR.
         """
         end_offset = self._offset + self._length
         with open(self._device_filename, "rb") as f:
             decoder = self._new_decoder(f)
-            decoder.decode()  # skip the header
+            # skip the header
+            decoder.decode()
             yield from _decode_cbor_values(decoder, end_offset)

--- a/kernel/comps/mariposa_data_capture/python/test_mariposa_data_reader.py
+++ b/kernel/comps/mariposa_data_capture/python/test_mariposa_data_reader.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for mariposa_data_reader."""
+
+from itertools import zip_longest
+import tempfile
+import unittest
+
+from contextlib import contextmanager
+from pathlib import Path
+
+import cbor2
+
+from mariposa_data_reader import DataCaptureDevice
+
+
+class TempImage:
+    """Helper class for creating a data capture device image for testing."""
+
+    def __init__(self):
+        """Initialize the builder with an empty temporary file."""
+        self._file = tempfile.NamedTemporaryFile(delete=False)
+
+    def write_bytes(self, data: bytes) -> None:
+        """Write raw bytes at the current position in the file."""
+        self._file.write(data)
+
+    def write_cbor(self, value) -> None:
+        """Write CBOR-encoded values at the current position in the file."""
+        cbor2.dump(value, self._file)
+
+    def write_padding(self, target_offset: int) -> None:
+        """Write 0xff bytes until reaching the specified offset."""
+        current_offset = self._file.tell()
+        if target_offset < current_offset:
+            raise ValueError("Target offset is before current position")
+
+        remaining = target_offset - current_offset
+        self.write_bytes(bytes([0xFF]) * remaining)
+
+    def finalize(self) -> Path:
+        """Close the file and return its path."""
+        self._file.close()
+        return Path(self._file.name)
+
+    def __enter__(self):
+        self._file.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        Path(self._file.name).unlink()
+        return self._file.__exit__(exc_type, exc_val, exc_tb)
+
+
+class TestDataCaptureDevice(unittest.TestCase):
+    @contextmanager
+    @staticmethod
+    def _test_file():
+        with TempImage() as img:
+            img.write_cbor({"offset": 0x1000, "length": 0x1000, "path": "test.name"})
+            img.write_cbor({"offset": 0x4000, "length": 0x1000, "path": "test.name[2]"})
+            img.write_padding(0x1000)
+            img.write_bytes(b"MARIPOSALDOSDATA\0")
+            img.write_cbor({"name": "test.name", "type_name": "Test", "oqueues": []})
+            img.write_cbor({"a": 1, "b": 2})
+            img.write_cbor({"a": 1, "b": 2})
+            img.write_cbor({"a": 1, "b": 2})
+            img.write_padding(0x4000)
+            img.write_bytes(b"MARIPOSALDOSDATA\0")
+            img.write_cbor(
+                {"name": "test.name[2]", "type_name": "Test2", "oqueues": []}
+            )
+            img.write_cbor({"x": 1, "y": 2})
+            img.write_cbor({"x": 1, "y": 2})
+            img.write_cbor({"x": 1, "y": 2})
+            img.write_padding(0x5000)
+            yield img.finalize()
+
+    def test_files(self):
+        with TestDataCaptureDevice._test_file() as test_filename:
+            device = DataCaptureDevice(test_filename)
+            self.assertEqual(len(device), 2)
+            self.assertEqual(device[0].path, "test.name")
+            self.assertEqual(device[1].path, "test.name[2]")
+
+    def test_no_files(self):
+        with TempImage() as img:
+            img.write_padding(0x1000)
+            device = DataCaptureDevice(img.finalize())
+            self.assertEqual(len(device), 0)
+
+    def test_first_file_records(self):
+        with TestDataCaptureDevice._test_file() as test_filename:
+            device = DataCaptureDevice(test_filename)
+            file = device[0]
+            self.assertEqual(file.path, "test.name")
+            self.assertEqual(file.type_name, "Test")
+
+            expected_records = [{"a": 1, "b": 2}, {"a": 1, "b": 2}, {"a": 1, "b": 2}]
+
+            for record, expected_record in zip_longest(file, expected_records):
+                self.assertDictEqual(record, expected_record)
+
+    def test_second_file_records(self):
+        with TestDataCaptureDevice._test_file() as test_filename:
+            device = DataCaptureDevice(test_filename)
+            file = device[1]
+            self.assertEqual(file.path, "test.name[2]")
+            self.assertEqual(file.type_name, "Test2")
+
+            expected_records = [{"x": 1, "y": 2}, {"x": 1, "y": 2}, {"x": 1, "y": 2}]
+
+            for record, expected_record in zip_longest(file, expected_records):
+                self.assertDictEqual(record, expected_record)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kernel/comps/mariposa_data_capture/src/data_buffering.rs
+++ b/kernel/comps/mariposa_data_capture/src/data_buffering.rs
@@ -1,63 +1,66 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use alloc::{boxed::Box, format, sync::Arc, vec::Vec};
-use core::error::Error;
+use alloc::{
+    string::{String, ToString as _},
+    sync::Arc,
+    vec::Vec,
+};
 
 use aster_block::{
     BLOCK_SIZE, BlockDevice,
     bio::{BioDirection, BioSegment},
     id::Bid,
 };
-use binary_serde::{BinarySerde, Endianness};
+use minicbor_serde::Serializer;
 use ostd::orpc::path::Path;
+use serde::Serialize;
+use snafu::ensure;
+
+use crate::{DataCaptureError, InsufficientSpaceSnafu};
 
 /// A buffer for managing data which will be written bit by bit, but the extracted in larger blocks.
 struct DataBuf {
-    data: Vec<u8>,
+    data: Serializer<Vec<u8>>,
 }
 
 impl DataBuf {
     /// Creates a new DataBuf with the specified size.
     pub fn new(size: usize) -> Self {
         DataBuf {
-            data: Vec::with_capacity(size),
+            data: Serializer::new(Vec::with_capacity(size)),
         }
     }
 
-    /// Writes a [`BinarySerde`] value to the buffer at the current offset.
-    ///
-    /// [`BinarySerde`] is derivable. See
-    /// https://docs.rs/binary_serde/latest/binary_serde/index.html.
+    /// Writes a [`Serialize`] value to the buffer at the current offset.
     pub fn write_value<T>(&mut self, v: &T)
     where
-        T: BinarySerde,
+        T: Serialize,
     {
-        let serialization_start = self.data.len();
-        self.data
-            .resize(serialization_start + T::SERIALIZED_SIZE, 0);
-        v.binary_serialize(&mut self.data[serialization_start..], Endianness::NATIVE);
+        v.serialize(&mut self.data).unwrap()
     }
 
     /// Writes raw bytes to the buffer at the current position.
     pub fn write_bytes(&mut self, v: &[u8]) {
-        self.data.extend(v);
+        let data = self.data.encoder_mut().writer_mut();
+        data.extend(v);
     }
 
     /// Returns a slice containing all written data in the buffer.
     pub fn written_data(&self) -> &[u8] {
-        &self.data
+        self.data.encoder().writer()
     }
 
     /// Removes the leading n bytes by shifting remaining data to start of buffer.
     pub fn delete(&mut self, n: usize) {
-        let remaining = self.data.len() - n;
-        self.data.drain(0..n);
-        debug_assert_eq!(self.data.len(), remaining);
+        let data = self.data.encoder_mut().writer_mut();
+        let remaining = data.len() - n;
+        data.drain(0..n);
+        debug_assert_eq!(data.len(), remaining);
     }
 
     /// Returns the number of bytes currently in the buffer.
     pub fn len(&self) -> usize {
-        self.data.len()
+        self.written_data().len()
     }
 }
 
@@ -66,88 +69,94 @@ pub(crate) struct ChunkingWriteWrapper {
     data_buf: DataBuf,
     pub(crate) block_device: Arc<dyn aster_block::BlockDevice>,
     pub(crate) current_bid: Bid,
+    end_bid: Bid,
 }
 
 impl ChunkingWriteWrapper {
     /// Create a new wrapper for chunking writes.
     pub fn new(
-        size: usize,
+        buffer_size: usize,
         block_device: Arc<dyn BlockDevice>,
         start_bid: Bid,
+        end_bid: Bid,
     ) -> ChunkingWriteWrapper {
         ChunkingWriteWrapper {
-            data_buf: DataBuf::new(size),
+            data_buf: DataBuf::new(buffer_size),
             block_device,
             current_bid: start_bid,
+            end_bid,
         }
     }
 
-    /// Writes a [`BinarySerde`] value to the output.
-    ///
-    /// [`BinarySerde`] is derivable. See
-    /// https://docs.rs/binary_serde/latest/binary_serde/index.html.
+    /// Writes a [`Serialize`] value to the output.
     ///
     /// See [`DataBuf::write_value`].
     pub fn write_value<T>(&mut self, v: &T)
     where
-        T: BinarySerde,
+        T: Serialize,
     {
         self.data_buf.write_value(v);
     }
 
     /// Flushes the buffer to storage if it contains more than one block's worth of data.
-    pub fn flush_if_needed(&mut self) -> Result<(), Box<dyn Error + 'static>> {
+    pub fn flush_if_needed(&mut self) -> Result<(), DataCaptureError> {
         if self.data_buf.len() > BLOCK_SIZE {
             let n_written = self.flush()?;
             self.current_bid = self.current_bid + 1;
             self.data_buf.delete(n_written);
+
+            // Flush again to write out any remaining data to the next page, and make sure there are
+            // 0xff terminators following the data.
+            self.flush()?;
         }
         Ok(())
     }
 
-    /// Flush the buffered data to storage regardless of the state.
+    /// Flush the buffered data to storage regardless of the state. If there is no data in the
+    /// buffer, this writes a block of 0xff (the CBOR "break" command). This serves to mark the end
+    /// of the data.
     ///
-    /// The same page may be written again if it was not full when this was called.
-    pub fn flush(&mut self) -> Result<usize, Box<dyn Error + 'static>> {
+    /// The same page may be written again if this is called again and if it was not full when this
+    /// was called the first time.
+    pub fn flush(&mut self) -> Result<usize, DataCaptureError> {
+        ensure!(self.current_bid < self.end_bid, InsufficientSpaceSnafu);
+
         let raw_data = self.data_buf.written_data();
         let bio_segment = BioSegment::alloc(1, BioDirection::ToDevice);
-        let n_written = bio_segment.writer()?.write(&mut raw_data.into());
+        let mut writer = bio_segment.writer().expect("segment direction known");
+        let n_written = writer.write(&mut raw_data.into());
+        writer.fill(0xffu8);
         let _ = self
             .block_device
             .write_blocks_async(self.current_bid, bio_segment)?;
         Ok(n_written)
     }
 
-    pub fn sync(&mut self) -> Result<(), Box<dyn Error + 'static>> {
+    /// Sync all of the data to the block device.
+    pub fn sync(&mut self) -> Result<(), DataCaptureError> {
+        self.flush()?;
         self.block_device.sync()?;
         Ok(())
     }
 
     /// Writes a structured header with magic number, type information, and paths.
-    pub fn write_header<T>(&mut self, paths: &[Path]) -> Result<(), Box<dyn Error + 'static>> {
+    pub fn write_header<T>(&mut self, name: &str, paths: &[Path]) -> Result<(), DataCaptureError> {
         // Write magic number
         let magic = b"MARIPOSALDOSDATA\0";
         self.data_buf.write_bytes(magic);
 
-        // Create JSON header with type information and optional paths
-        let mut json_header = format!("{{\"type\":\"{}\"", core::any::type_name::<T>());
-
-        json_header.push_str(", \"oqueues\": [");
-        for (i, path) in paths.iter().enumerate() {
-            json_header.push_str(&format!("{}\"{}\"", if i > 0 { "," } else { "" }, path));
+        #[derive(Serialize)]
+        struct Header<'a> {
+            name: &'a str,
+            type_name: &'a str,
+            oqueues: Vec<String>,
         }
-        json_header.push(']');
 
-        json_header.push('}');
-        self.data_buf.write_bytes(json_header.as_bytes());
-
-        self.data_buf.write_bytes(&[0]);
-
-        let padding = 64 - (self.data_buf.len() % 64);
-        if padding != 0 {
-            // The weird [0; 64] avoids an allocation by referencing a static block of 0s.
-            self.data_buf.write_bytes(&[0; 64][..padding]);
-        }
+        self.data_buf.write_value(&Header {
+            name,
+            type_name: core::any::type_name::<T>(),
+            oqueues: paths.iter().map(|p| p.to_string()).collect(),
+        });
 
         Ok(())
     }
@@ -170,7 +179,7 @@ mod test {
 
     #[ktest]
     fn test_write_value() {
-        #[derive(Debug, PartialEq, Eq, BinarySerde)]
+        #[derive(Debug, PartialEq, Eq, Serialize)]
         struct TestStruct {
             a: u32,
             b: u16,
@@ -186,12 +195,12 @@ mod test {
 
         // Verify the bytes were written correctly
         let data = buf.written_data();
-        assert_eq!(data.len(), 6);
         assert_eq!(
-            u32::from_le_bytes(data[..4].try_into().unwrap()),
-            0x12345678
-        );
-        assert_eq!(u16::from_le_bytes(data[4..6].try_into().unwrap()), 0x9012);
+            data,
+            &[
+                0xa2, 0x61, 0x61, 0x1a, 0x12, 0x34, 0x56, 0x78, 0x61, 0x62, 0x19, 0x90, 0x12
+            ]
+        )
     }
 
     #[ktest]
@@ -227,10 +236,10 @@ mod test {
             data_buf: DataBuf::new(4096 * 2),
             block_device: block_device.clone(),
             current_bid: Bid::new(0),
+            end_bid: Bid::new(4),
         };
 
-        wrapper.write_header::<u32>(&paths).unwrap();
-        assert_eq!(wrapper.data_buf.len(), 64);
+        wrapper.write_header::<u32>("test", &paths).unwrap();
         assert_eq!(&wrapper.data_buf.written_data()[..16], b"MARIPOSALDOSDATA");
 
         wrapper.flush().unwrap();
@@ -244,6 +253,7 @@ mod test {
             data_buf: DataBuf::new(4096),
             block_device: block_device.clone(),
             current_bid: Bid::new(0),
+            end_bid: Bid::new(4),
         };
 
         // Test case 1: Buffer doesn't need flushing (<= BLOCK_SIZE)

--- a/kernel/comps/mariposa_data_capture/src/data_buffering.rs
+++ b/kernel/comps/mariposa_data_capture/src/data_buffering.rs
@@ -18,6 +18,10 @@ use snafu::ensure;
 
 use crate::{DataCaptureError, InsufficientSpaceSnafu};
 
+/// The "magic number" included at the start of files to catch errors and allow finding them in
+/// corrupted data.
+const MAGIC: &[u8; 17] = b"MARIPOSALDOSDATA\0";
+
 /// A buffer for managing data which will be written bit by bit, but the extracted in larger blocks.
 struct DataBuf {
     data: Serializer<Vec<u8>>,
@@ -138,8 +142,7 @@ impl ChunkingWriteWrapper {
     /// Writes a structured header with magic number, type information, and paths.
     pub fn write_header<T>(&mut self, name: &str, paths: &[Path]) -> Result<(), DataCaptureError> {
         // Write magic number
-        let magic = b"MARIPOSALDOSDATA\0";
-        self.data_buf.write_bytes(magic);
+        self.data_buf.write_bytes(MAGIC);
 
         #[derive(Serialize)]
         struct Header<'a> {

--- a/kernel/comps/mariposa_data_capture/src/data_buffering.rs
+++ b/kernel/comps/mariposa_data_capture/src/data_buffering.rs
@@ -102,7 +102,7 @@ impl ChunkingWriteWrapper {
         self.data_buf.write_value(v);
     }
 
-    /// Flushes the a block to storage if it contains more than one block's worth of data.
+    /// Flushes a block to storage if it contains more than one block's worth of data.
     pub fn flush_if_needed(&mut self) -> Result<(), DataCaptureError> {
         if self.data_buf.len() > BLOCK_SIZE {
             let n_written = self.flush()?;

--- a/kernel/comps/mariposa_data_capture/src/data_buffering.rs
+++ b/kernel/comps/mariposa_data_capture/src/data_buffering.rs
@@ -98,16 +98,12 @@ impl ChunkingWriteWrapper {
         self.data_buf.write_value(v);
     }
 
-    /// Flushes the buffer to storage if it contains more than one block's worth of data.
+    /// Flushes the a block to storage if it contains more than one block's worth of data.
     pub fn flush_if_needed(&mut self) -> Result<(), DataCaptureError> {
         if self.data_buf.len() > BLOCK_SIZE {
             let n_written = self.flush()?;
             self.current_bid = self.current_bid + 1;
             self.data_buf.delete(n_written);
-
-            // Flush again to write out any remaining data to the next page, and make sure there are
-            // 0xff terminators following the data.
-            self.flush()?;
         }
         Ok(())
     }

--- a/kernel/comps/mariposa_data_capture/src/data_capture_device.rs
+++ b/kernel/comps/mariposa_data_capture/src/data_capture_device.rs
@@ -32,6 +32,8 @@ pub struct FileDescriptor {
     pub path: Path,
 }
 
+/// The number of blocks allocated for the directory. This must match the DIRECTORY_BLOCKS constant
+/// in `mariposa_data_reader.py`.
 const DIRECTORY_BLOCKS: usize = 1;
 
 /// A wrapper around a [`BlockDevice`] which supports creating [`DataCaptureFile`]s.

--- a/kernel/comps/mariposa_data_capture/src/data_capture_device.rs
+++ b/kernel/comps/mariposa_data_capture/src/data_capture_device.rs
@@ -5,18 +5,25 @@
 //! This module provides [`DataCaptureDevice`], which manages block storage devices and creates
 //! [`DataCaptureFile`](crate::data_capture_file::DataCaptureFile) instances.
 
-use alloc::sync::Arc;
+use alloc::{
+    string::{String, ToString as _},
+    sync::Arc,
+};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use aster_block::{self, BlockDevice, SECTOR_SIZE};
+use aster_block::{self, BLOCK_SIZE, BlockDevice, SECTOR_SIZE, id::Bid};
 use ostd::{
     new_server,
-    orpc::{errors::RPCError, framework::Server, orpc_impl, orpc_server, orpc_trait, path::Path},
-    ostd_error,
+    orpc::{framework::Server, orpc_impl, orpc_server, orpc_trait, path::Path},
+    sync::Mutex,
 };
-use snafu::{Snafu, ensure};
+use serde::Serialize;
+use snafu::ensure;
 
-use crate::DataCaptureFileBuilder;
+use crate::{
+    DataCaptureError, DataCaptureFileBuilder, InsufficientSpaceSnafu,
+    data_buffering::ChunkingWriteWrapper,
+};
 
 /// Describes a file to be created on the device
 #[derive(Debug, Clone)]
@@ -25,16 +32,7 @@ pub struct FileDescriptor {
     pub path: Path,
 }
 
-#[non_exhaustive]
-#[ostd_error]
-#[derive(Debug, Snafu)]
-#[snafu()]
-pub enum DataCaptureDeviceError {
-    #[snafu(transparent)]
-    RPCError { source: RPCError },
-    #[snafu(display("Insufficient space on device ({context})"))]
-    InsufficientSpace {},
-}
+const DIRECTORY_BLOCKS: usize = 1;
 
 /// A wrapper around a [`BlockDevice`] which supports creating [`DataCaptureFile`]s.
 #[orpc_trait]
@@ -45,7 +43,7 @@ pub trait DataCaptureDevice {
     fn new_file(
         &self,
         descriptor: FileDescriptor,
-    ) -> Result<DataCaptureFileBuilder, DataCaptureDeviceError>;
+    ) -> Result<DataCaptureFileBuilder, DataCaptureError>;
 }
 
 /// An implementation of [`DataCaptureDevice`].
@@ -53,13 +51,20 @@ pub trait DataCaptureDevice {
 pub struct DataCaptureDeviceServer {
     block_device: Arc<dyn BlockDevice>,
     next_block_offset: AtomicUsize,
+    directory_writer: Mutex<ChunkingWriteWrapper>,
 }
 
 impl DataCaptureDeviceServer {
     pub fn new(block_device: Arc<dyn BlockDevice>) -> Arc<DataCaptureDeviceServer> {
         new_server!(|_| DataCaptureDeviceServer {
+            directory_writer: Mutex::new(ChunkingWriteWrapper::new(
+                BLOCK_SIZE * 2,
+                block_device.clone(),
+                Bid::from_offset(0),
+                Bid::from_offset(DIRECTORY_BLOCKS * BLOCK_SIZE)
+            )),
             block_device,
-            next_block_offset: AtomicUsize::new(0),
+            next_block_offset: AtomicUsize::new(DIRECTORY_BLOCKS * BLOCK_SIZE),
         })
     }
 }
@@ -69,15 +74,31 @@ impl DataCaptureDevice for DataCaptureDeviceServer {
     fn new_file(
         &self,
         descriptor: FileDescriptor,
-    ) -> Result<DataCaptureFileBuilder, DataCaptureDeviceError> {
-        let start = self
-            .next_block_offset
-            .fetch_add(descriptor.length, Ordering::Relaxed);
-        let end = start + descriptor.length;
+    ) -> Result<DataCaptureFileBuilder, DataCaptureError> {
+        let length = descriptor.length.next_multiple_of(BLOCK_SIZE);
+        let start = self.next_block_offset.fetch_add(length, Ordering::Relaxed);
+        let end = start + length;
         ensure!(
             end <= self.block_device.metadata().nr_sectors * SECTOR_SIZE,
             InsufficientSpaceSnafu
         );
+
+        #[derive(Serialize)]
+        struct FileRecord {
+            offset: u64,
+            length: u64,
+            path: String,
+        }
+
+        let mut writer = self.directory_writer.lock();
+        writer.write_value(&FileRecord {
+            offset: start as u64,
+            length: length as u64,
+            path: descriptor.path.to_string(),
+        });
+        writer.sync()?;
+        drop(writer);
+
         Ok(DataCaptureFileBuilder {
             block_device: self.block_device.clone(),
             path: descriptor.path,

--- a/kernel/comps/mariposa_data_capture/src/data_capture_file.rs
+++ b/kernel/comps/mariposa_data_capture/src/data_capture_file.rs
@@ -61,8 +61,6 @@ pub trait DataCaptureFile<T: Copy + Send + Serialize>: Any {
     /// Attach a new OQueue to the output. If output has already started, then the path will not
     /// appear in the block header.
     fn register_observer(&self, attachment: ObserverRegistration<T>) -> Result<(), RPCError>;
-    /// Flush any data remaining in the output buffers to disk.
-    fn flush(&self) -> Result<(), RPCError>;
     /// Sync writes to disk.
     fn sync(&self) -> Result<(), RPCError>;
     /// Enable capturing to this file.
@@ -74,7 +72,6 @@ pub trait DataCaptureFile<T: Copy + Send + Serialize>: Any {
 /// Command enum for DataCaptureFile operations
 enum DataCaptureFileCommand<T: Copy + Send + Serialize + 'static> {
     RegisterObserver(ObserverRegistration<T>),
-    Flush,
     Sync,
     Stop,
 }
@@ -85,7 +82,6 @@ impl<T: Copy + Send + Serialize + 'static> core::fmt::Debug for DataCaptureFileC
             Self::RegisterObserver(arg0) => {
                 f.debug_tuple("DataCaptureFileCommand").field(arg0).finish()
             }
-            Self::Flush => write!(f, "Flush"),
             Self::Sync => write!(f, "Sync"),
             Self::Stop => write!(f, "Stop"),
         }
@@ -141,9 +137,6 @@ impl<T: Copy + Send + Serialize + 'static> DataCaptureFileServerThread<T> {
                             paths.push(path);
                         }
                     }
-                    DataCaptureFileCommand::Flush => {
-                        data_buf_handler.flush()?;
-                    }
                     DataCaptureFileCommand::Sync => {
                         data_buf_handler.sync()?;
                     }
@@ -192,11 +185,6 @@ impl<T: Copy + Send + Serialize> DataCaptureFile<T> for DataCaptureFileServer<T>
     fn register_observer(&self, attachment: ObserverRegistration<T>) -> Result<(), RPCError> {
         self.command_producer
             .produce(DataCaptureFileCommand::RegisterObserver(attachment));
-        Ok(())
-    }
-
-    fn flush(&self) -> Result<(), RPCError> {
-        self.command_producer.produce(DataCaptureFileCommand::Flush);
         Ok(())
     }
 

--- a/kernel/comps/mariposa_data_capture/src/data_capture_file.rs
+++ b/kernel/comps/mariposa_data_capture/src/data_capture_file.rs
@@ -18,11 +18,10 @@
 //! [`DataCaptureFile`] has a thread which will observe all OQueues attach via
 //! [`DataCaptureFile::register_observer`].
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use core::{any::Any, error::Error, sync::atomic::AtomicBool};
+use alloc::{string::ToString as _, sync::Arc, vec::Vec};
+use core::{any::Any, sync::atomic::AtomicBool};
 
 use aster_block::{BLOCK_SIZE, BlockDevice, id::Bid};
-use binary_serde::BinarySerde;
 use ostd::{
     new_server,
     orpc::{
@@ -37,27 +36,28 @@ use ostd::{
     },
     path,
 };
+use serde::Serialize;
 
-use crate::data_buffering::ChunkingWriteWrapper;
+use crate::{DataCaptureError, data_buffering::ChunkingWriteWrapper};
 
 /// Registration information for an OQueue observer
-pub struct ObserverRegistration<T: Copy + Send + BinarySerde> {
+pub struct ObserverRegistration<T: Copy + Send + Serialize> {
     /// The path of the OQueue this is observing
     pub path: Path,
     /// An observer attachment at the appropriate type.
     pub observer: StrongObserver<T>,
 }
 
-impl<T: Copy + Send + BinarySerde> core::fmt::Debug for ObserverRegistration<T> {
+impl<T: Copy + Send + Serialize> core::fmt::Debug for ObserverRegistration<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OQueueAttachment")
+        f.debug_struct("ObserverRegistration")
             .field("path", &self.path)
             .finish()
     }
 }
 
 #[orpc_trait]
-pub trait DataCaptureFile<T: Copy + Send + BinarySerde>: Any {
+pub trait DataCaptureFile<T: Copy + Send + Serialize>: Any {
     /// Attach a new OQueue to the output. If output has already started, then the path will not
     /// appear in the block header.
     fn register_observer(&self, attachment: ObserverRegistration<T>) -> Result<(), RPCError>;
@@ -72,17 +72,19 @@ pub trait DataCaptureFile<T: Copy + Send + BinarySerde>: Any {
 }
 
 /// Command enum for DataCaptureFile operations
-enum DataCaptureFileCommand<T: Copy + Send + BinarySerde + 'static> {
+enum DataCaptureFileCommand<T: Copy + Send + Serialize + 'static> {
     RegisterObserver(ObserverRegistration<T>),
     Flush,
     Sync,
     Stop,
 }
 
-impl<T: Copy + Send + BinarySerde + 'static> core::fmt::Debug for DataCaptureFileCommand<T> {
+impl<T: Copy + Send + Serialize + 'static> core::fmt::Debug for DataCaptureFileCommand<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::RegisterObserver(arg0) => f.debug_tuple("AttachOqueue").field(arg0).finish(),
+            Self::RegisterObserver(arg0) => {
+                f.debug_tuple("DataCaptureFileCommand").field(arg0).finish()
+            }
             Self::Flush => write!(f, "Flush"),
             Self::Sync => write!(f, "Sync"),
             Self::Stop => write!(f, "Stop"),
@@ -91,14 +93,15 @@ impl<T: Copy + Send + BinarySerde + 'static> core::fmt::Debug for DataCaptureFil
 }
 
 #[orpc_server(DataCaptureFile<T>)]
-struct DataCaptureFileServer<T: Copy + Send + BinarySerde + 'static> {
+struct DataCaptureFileServer<T: Copy + Send + Serialize + 'static> {
     command_oqueue: ConsumableOQueueRef<DataCaptureFileCommand<T>>,
     command_producer: ValueProducer<DataCaptureFileCommand<T>>,
     started: AtomicBool,
     stopped: AtomicBool,
 }
 
-pub struct DataCaptureFileServerThread<T: Copy + Send + BinarySerde + 'static> {
+pub struct DataCaptureFileServerThread<T: Copy + Send + Serialize + 'static> {
+    path: Path,
     command_consumer: Consumer<DataCaptureFileCommand<T>>,
     block_device: Arc<dyn aster_block::BlockDevice>,
     start_bid: Bid,
@@ -106,10 +109,14 @@ pub struct DataCaptureFileServerThread<T: Copy + Send + BinarySerde + 'static> {
     server: Arc<DataCaptureFileServer<T>>,
 }
 
-impl<T: Copy + Send + BinarySerde + 'static> DataCaptureFileServerThread<T> {
-    fn run(&self) -> Result<(), Box<dyn Error>> {
-        let mut data_buf_handler =
-            ChunkingWriteWrapper::new(BLOCK_SIZE * 2, self.block_device.clone(), self.start_bid);
+impl<T: Copy + Send + Serialize + 'static> DataCaptureFileServerThread<T> {
+    fn run(&self) -> Result<(), DataCaptureError> {
+        let mut data_buf_handler = ChunkingWriteWrapper::new(
+            BLOCK_SIZE * 2,
+            self.block_device.clone(),
+            self.start_bid,
+            self.end_bid,
+        );
         let mut observers: Vec<StrongObserver<T>> = Default::default();
         // The paths of the attached OQueues. Once the header is written this is set to None and
         // paths are no longer collected even if more OQueues are attached.
@@ -141,6 +148,7 @@ impl<T: Copy + Send + BinarySerde + 'static> DataCaptureFileServerThread<T> {
                         data_buf_handler.sync()?;
                     }
                     DataCaptureFileCommand::Stop => {
+                        data_buf_handler.sync()?;
                         self.server
                             .stopped
                             .store(true, core::sync::atomic::Ordering::SeqCst);
@@ -160,7 +168,10 @@ impl<T: Copy + Send + BinarySerde + 'static> DataCaptureFileServerThread<T> {
                 while let Ok(Some(v)) = o.try_strong_observe() {
                     if started {
                         if paths.is_some() {
-                            data_buf_handler.write_header::<T>(paths.as_ref().unwrap())?;
+                            data_buf_handler.write_header::<T>(
+                                &self.path.to_string(),
+                                paths.as_ref().unwrap(),
+                            )?;
                             paths = None;
                         }
 
@@ -177,7 +188,7 @@ impl<T: Copy + Send + BinarySerde + 'static> DataCaptureFileServerThread<T> {
 }
 
 #[orpc_impl]
-impl<T: Copy + Send + BinarySerde> DataCaptureFile<T> for DataCaptureFileServer<T> {
+impl<T: Copy + Send + Serialize> DataCaptureFile<T> for DataCaptureFileServer<T> {
     fn register_observer(&self, attachment: ObserverRegistration<T>) -> Result<(), RPCError> {
         self.command_producer
             .produce(DataCaptureFileCommand::RegisterObserver(attachment));
@@ -225,7 +236,7 @@ impl DataCaptureFileBuilder {
     /// Construct the [`DataCaptureFile`] for a specific type of data.
     pub fn build<T>(self) -> Arc<dyn DataCaptureFile<T>>
     where
-        T: Copy + Send + BinarySerde + 'static,
+        T: Copy + Send + Serialize + 'static,
     {
         // We manually context switch into the server here. This is not something we should
         // generally do, but this build function is required and can't be on a server (due to the
@@ -246,16 +257,17 @@ impl DataCaptureFileBuilder {
 
                 spawn_thread(server.clone(), {
                     let thread = DataCaptureFileServerThread {
+                        path: self.path.clone(),
                         command_consumer: server
                             .command_oqueue
                             .attach_consumer()
                             .expect("single purpose OQueue failed."),
                         block_device: self.block_device,
-                        start_bid: Bid::new(self.start as u64),
-                        end_bid: Bid::new(self.end as u64),
+                        start_bid: Bid::from_offset(self.start),
+                        end_bid: Bid::from_offset(self.end),
                         server: server.clone(),
                     };
-                    move || thread.run()
+                    move || Ok(thread.run()?)
                 });
 
                 Ok(server)

--- a/kernel/comps/mariposa_data_capture/src/legacy/data_capture_device.rs
+++ b/kernel/comps/mariposa_data_capture/src/legacy/data_capture_device.rs
@@ -4,34 +4,31 @@
 //!
 //! See [`crate::data_capture_device`] for full documentation.
 
-use alloc::sync::Arc;
+use alloc::{
+    string::{String, ToString as _},
+    sync::Arc,
+};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use aster_block::{self, BlockDevice, SECTOR_SIZE};
+use aster_block::{self, BLOCK_SIZE, BlockDevice, SECTOR_SIZE, id::Bid};
 use ostd::{
     new_server,
-    orpc::{errors::RPCError, framework::Server, orpc_impl, orpc_server, orpc_trait},
-    ostd_error,
+    orpc::{framework::Server, orpc_impl, orpc_server, orpc_trait, path::Path},
+    sync::Mutex,
 };
-use snafu::{Snafu, ensure};
+use serde::Serialize;
+use snafu::ensure;
 
 use super::data_capture_file::DataCaptureFileBuilder;
+use crate::{DataCaptureError, InsufficientSpaceSnafu, data_buffering::ChunkingWriteWrapper};
+
+const DIRECTORY_BLOCKS: usize = 1;
 
 /// TEMPORARY: Describes a file to be created on the device.
 #[derive(Debug, Clone)]
 pub struct FileDescriptor {
     pub length: usize,
-}
-
-#[non_exhaustive]
-#[ostd_error]
-#[derive(Debug, Snafu)]
-#[snafu()]
-pub enum DataCaptureDeviceError {
-    #[snafu(transparent)]
-    RPCError { source: RPCError },
-    #[snafu(display("Insufficient space on device ({context})"))]
-    InsufficientSpace {},
+    pub path: Path,
 }
 
 /// TEMPORARY: A wrapper around a [`BlockDevice`] which supports creating legacy-OQueue-backed
@@ -44,7 +41,7 @@ pub trait DataCaptureDevice {
     fn new_file(
         &self,
         descriptor: FileDescriptor,
-    ) -> Result<DataCaptureFileBuilder, DataCaptureDeviceError>;
+    ) -> Result<DataCaptureFileBuilder, DataCaptureError>;
 }
 
 /// TEMPORARY: An implementation of [`DataCaptureDevice`].
@@ -52,13 +49,20 @@ pub trait DataCaptureDevice {
 pub struct DataCaptureDeviceServer {
     block_device: Arc<dyn BlockDevice>,
     next_block_offset: AtomicUsize,
+    directory_writer: Mutex<ChunkingWriteWrapper>,
 }
 
 impl DataCaptureDeviceServer {
     pub fn new(block_device: Arc<dyn BlockDevice>) -> Arc<DataCaptureDeviceServer> {
         new_server!(|_| DataCaptureDeviceServer {
+            directory_writer: Mutex::new(ChunkingWriteWrapper::new(
+                BLOCK_SIZE * 2,
+                block_device.clone(),
+                Bid::from_offset(0),
+                Bid::from_offset(DIRECTORY_BLOCKS * BLOCK_SIZE)
+            )),
             block_device,
-            next_block_offset: AtomicUsize::new(0),
+            next_block_offset: AtomicUsize::new(DIRECTORY_BLOCKS * BLOCK_SIZE),
         })
     }
 }
@@ -68,17 +72,34 @@ impl DataCaptureDevice for DataCaptureDeviceServer {
     fn new_file(
         &self,
         descriptor: FileDescriptor,
-    ) -> Result<DataCaptureFileBuilder, DataCaptureDeviceError> {
-        let start = self
-            .next_block_offset
-            .fetch_add(descriptor.length, Ordering::Relaxed);
-        let end = start + descriptor.length;
+    ) -> Result<DataCaptureFileBuilder, DataCaptureError> {
+        let length = descriptor.length.next_multiple_of(BLOCK_SIZE);
+        let start = self.next_block_offset.fetch_add(length, Ordering::Relaxed);
+        let end = start + length;
         ensure!(
             end <= self.block_device.metadata().nr_sectors * SECTOR_SIZE,
             InsufficientSpaceSnafu
         );
+
+        #[derive(Serialize)]
+        struct FileRecord {
+            offset: u64,
+            length: u64,
+            path: String,
+        }
+
+        let mut writer = self.directory_writer.lock();
+        writer.write_value(&FileRecord {
+            offset: start as u64,
+            length: length as u64,
+            path: descriptor.path.to_string(),
+        });
+        writer.sync()?;
+        drop(writer);
+
         Ok(DataCaptureFileBuilder {
             block_device: self.block_device.clone(),
+            path: descriptor.path,
             start,
             end,
             server: self.orpc_server_base().get_ref().unwrap(),

--- a/kernel/comps/mariposa_data_capture/src/legacy/data_capture_file.rs
+++ b/kernel/comps/mariposa_data_capture/src/legacy/data_capture_file.rs
@@ -5,11 +5,10 @@
 //! This is otherwise identical in structure and purpose to the non-legacy version. See
 //! [`crate::data_capture_file`] for full documentation.
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use core::{any::Any, error::Error, sync::atomic::AtomicBool};
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
+use core::{any::Any, sync::atomic::AtomicBool};
 
 use aster_block::{BLOCK_SIZE, BlockDevice, id::Bid};
-use binary_serde::BinarySerde;
 use ostd::{
     new_server,
     orpc::{
@@ -17,26 +16,28 @@ use ostd::{
         framework::{Server, spawn_thread},
         legacy_oqueue::{Consumer, OQueue, StrongObserver, locking::LockingQueue},
         orpc_impl, orpc_server, orpc_trait,
+        path::Path,
         sync::{BlockOnMany, Blocker},
     },
 };
+use serde::Serialize;
 
-use crate::data_buffering::ChunkingWriteWrapper;
+use crate::{DataCaptureError, data_buffering::ChunkingWriteWrapper};
 
 /// TEMPORARY: Registration information for a legacy OQueue observer.
-pub struct ObserverRegistration<T: Copy + Send + BinarySerde> {
+pub struct ObserverRegistration<T: Copy + Send + Serialize> {
     /// TEMPORARY: A strong observer attachment on the legacy OQueue.
     pub observer: Box<dyn StrongObserver<T>>,
 }
 
-impl<T: Copy + Send + BinarySerde> core::fmt::Debug for ObserverRegistration<T> {
+impl<T: Copy + Send + Serialize> core::fmt::Debug for ObserverRegistration<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ObserverRegistration").finish()
     }
 }
 
 #[orpc_trait]
-pub trait DataCaptureFile<T: Copy + Send + BinarySerde>: Any {
+pub trait DataCaptureFile<T: Copy + Send + Serialize>: Any {
     /// TEMPORARY: Attach a new legacy OQueue to the output. If output has already started, then the
     /// path will not appear in the block header.
     fn register_observer(&self, attachment: ObserverRegistration<T>) -> Result<(), RPCError>;
@@ -51,17 +52,19 @@ pub trait DataCaptureFile<T: Copy + Send + BinarySerde>: Any {
 }
 
 /// TEMPORARY: Command enum for [`DataCaptureFile`] operations.
-enum DataCaptureFileCommand<T: Copy + Send + BinarySerde + 'static> {
+enum DataCaptureFileCommand<T: Copy + Send + Serialize + 'static> {
     RegisterObserver(ObserverRegistration<T>),
     Flush,
     Sync,
     Stop,
 }
 
-impl<T: Copy + Send + BinarySerde + 'static> core::fmt::Debug for DataCaptureFileCommand<T> {
+impl<T: Copy + Send + Serialize + 'static> core::fmt::Debug for DataCaptureFileCommand<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::RegisterObserver(reg) => f.debug_tuple("RegisterObserver").field(reg).finish(),
+            Self::RegisterObserver(reg) => {
+                f.debug_tuple("DataCaptureFileCommand").field(reg).finish()
+            }
             Self::Flush => write!(f, "Flush"),
             Self::Sync => write!(f, "Sync"),
             Self::Stop => write!(f, "Stop"),
@@ -70,24 +73,29 @@ impl<T: Copy + Send + BinarySerde + 'static> core::fmt::Debug for DataCaptureFil
 }
 
 #[orpc_server(DataCaptureFile<T>)]
-struct DataCaptureFileServer<T: Copy + Send + BinarySerde + 'static> {
+struct DataCaptureFileServer<T: Copy + Send + Serialize + 'static> {
     command_queue: Arc<LockingQueue<DataCaptureFileCommand<T>>>,
     started: AtomicBool,
     stopped: AtomicBool,
 }
 
-struct DataCaptureFileServerThread<T: Copy + Send + BinarySerde + 'static> {
+struct DataCaptureFileServerThread<T: Copy + Send + Serialize + 'static> {
     command_consumer: Box<dyn Consumer<DataCaptureFileCommand<T>>>,
     block_device: Arc<dyn BlockDevice>,
+    path: Path,
     start_bid: Bid,
     end_bid: Bid,
     server: Arc<DataCaptureFileServer<T>>,
 }
 
-impl<T: Copy + Send + BinarySerde + 'static> DataCaptureFileServerThread<T> {
-    fn run(&self) -> Result<(), Box<dyn Error>> {
-        let mut data_buf_handler =
-            ChunkingWriteWrapper::new(BLOCK_SIZE * 2, self.block_device.clone(), self.start_bid);
+impl<T: Copy + Send + Serialize + 'static> DataCaptureFileServerThread<T> {
+    fn run(&self) -> Result<(), DataCaptureError> {
+        let mut data_buf_handler = ChunkingWriteWrapper::new(
+            BLOCK_SIZE * 2,
+            self.block_device.clone(),
+            self.start_bid,
+            self.end_bid,
+        );
         let mut observers: Vec<Box<dyn StrongObserver<T>>> = Default::default();
         let mut headers_written = false;
         let mut block_handler = BlockOnMany::new();
@@ -111,6 +119,7 @@ impl<T: Copy + Send + BinarySerde + 'static> DataCaptureFileServerThread<T> {
                         data_buf_handler.sync()?;
                     }
                     DataCaptureFileCommand::Stop => {
+                        data_buf_handler.sync()?;
                         self.server
                             .stopped
                             .store(true, core::sync::atomic::Ordering::SeqCst);
@@ -130,7 +139,7 @@ impl<T: Copy + Send + BinarySerde + 'static> DataCaptureFileServerThread<T> {
                 while let Some(v) = o.try_strong_observe() {
                     if capturing {
                         if !headers_written {
-                            data_buf_handler.write_header::<T>(&[])?;
+                            data_buf_handler.write_header::<T>(&self.path.to_string(), &[])?;
                             headers_written = true;
                         }
 
@@ -147,7 +156,7 @@ impl<T: Copy + Send + BinarySerde + 'static> DataCaptureFileServerThread<T> {
 }
 
 #[orpc_impl]
-impl<T: Copy + Send + BinarySerde> DataCaptureFile<T> for DataCaptureFileServer<T> {
+impl<T: Copy + Send + Serialize> DataCaptureFile<T> for DataCaptureFileServer<T> {
     fn register_observer(&self, attachment: ObserverRegistration<T>) -> Result<(), RPCError> {
         self.command_queue
             .produce(DataCaptureFileCommand::RegisterObserver(attachment))
@@ -190,6 +199,7 @@ impl<T: Copy + Send + BinarySerde> DataCaptureFile<T> for DataCaptureFileServer<
 /// TEMPORARY: A builder for a [`DataCaptureFile`] provided by a [`DataCaptureDevice`].
 pub struct DataCaptureFileBuilder {
     pub(crate) block_device: Arc<dyn BlockDevice>,
+    pub(crate) path: Path,
     pub(crate) start: usize,
     pub(crate) end: usize,
     pub(crate) server: Arc<dyn Server>,
@@ -199,7 +209,7 @@ impl DataCaptureFileBuilder {
     /// TEMPORARY: Construct the [`DataCaptureFile`] for a specific type of data.
     pub fn build<T>(self) -> Arc<dyn DataCaptureFile<T>>
     where
-        T: Copy + Send + BinarySerde + 'static,
+        T: Copy + Send + Serialize + 'static,
     {
         Server::orpc_server_base(self.server.as_ref())
             .call_in_context(move || -> Result<Arc<DataCaptureFileServer<T>>, RPCError> {
@@ -216,11 +226,12 @@ impl DataCaptureFileBuilder {
                             .attach_consumer()
                             .expect("single purpose OQueue failed."),
                         block_device: self.block_device,
-                        start_bid: Bid::new(self.start as u64),
-                        end_bid: Bid::new(self.end as u64),
+                        path: self.path,
+                        start_bid: Bid::from_offset(self.start),
+                        end_bid: Bid::from_offset(self.end),
                         server: server.clone(),
                     };
-                    move || thread.run()
+                    move || Ok(thread.run()?)
                 });
 
                 Ok(server)

--- a/kernel/comps/mariposa_data_capture/src/legacy/data_capture_file.rs
+++ b/kernel/comps/mariposa_data_capture/src/legacy/data_capture_file.rs
@@ -41,8 +41,6 @@ pub trait DataCaptureFile<T: Copy + Send + Serialize>: Any {
     /// TEMPORARY: Attach a new legacy OQueue to the output. If output has already started, then the
     /// path will not appear in the block header.
     fn register_observer(&self, attachment: ObserverRegistration<T>) -> Result<(), RPCError>;
-    /// TEMPORARY: Flush any data remaining in the output buffers to disk.
-    fn flush(&self) -> Result<(), RPCError>;
     /// TEMPORARY: Sync writes to disk.
     fn sync(&self) -> Result<(), RPCError>;
     /// TEMPORARY: Enable capturing to this file.
@@ -54,7 +52,6 @@ pub trait DataCaptureFile<T: Copy + Send + Serialize>: Any {
 /// TEMPORARY: Command enum for [`DataCaptureFile`] operations.
 enum DataCaptureFileCommand<T: Copy + Send + Serialize + 'static> {
     RegisterObserver(ObserverRegistration<T>),
-    Flush,
     Sync,
     Stop,
 }
@@ -65,7 +62,6 @@ impl<T: Copy + Send + Serialize + 'static> core::fmt::Debug for DataCaptureFileC
             Self::RegisterObserver(reg) => {
                 f.debug_tuple("DataCaptureFileCommand").field(reg).finish()
             }
-            Self::Flush => write!(f, "Flush"),
             Self::Sync => write!(f, "Sync"),
             Self::Stop => write!(f, "Stop"),
         }
@@ -112,9 +108,6 @@ impl<T: Copy + Send + Serialize + 'static> DataCaptureFileServerThread<T> {
                     DataCaptureFileCommand::RegisterObserver(ObserverRegistration { observer }) => {
                         observers.push(observer);
                     }
-                    DataCaptureFileCommand::Flush => {
-                        data_buf_handler.flush()?;
-                    }
                     DataCaptureFileCommand::Sync => {
                         data_buf_handler.sync()?;
                     }
@@ -160,13 +153,6 @@ impl<T: Copy + Send + Serialize> DataCaptureFile<T> for DataCaptureFileServer<T>
     fn register_observer(&self, attachment: ObserverRegistration<T>) -> Result<(), RPCError> {
         self.command_queue
             .produce(DataCaptureFileCommand::RegisterObserver(attachment))
-            .unwrap();
-        Ok(())
-    }
-
-    fn flush(&self) -> Result<(), RPCError> {
-        self.command_queue
-            .produce(DataCaptureFileCommand::Flush)
             .unwrap();
         Ok(())
     }

--- a/kernel/comps/mariposa_data_capture/src/legacy/mod.rs
+++ b/kernel/comps/mariposa_data_capture/src/legacy/mod.rs
@@ -22,7 +22,10 @@ mod legacy_tests {
     use aster_block::test_utils::MemoryDisk;
     use ostd::{
         assertion::sleep,
-        orpc::legacy_oqueue::{OQueue as _, locking::ObservableLockingQueue},
+        orpc::{
+            legacy_oqueue::{OQueue as _, locking::ObservableLockingQueue},
+            path::Path,
+        },
         prelude::*,
     };
 
@@ -37,7 +40,10 @@ mod legacy_tests {
         let device = DataCaptureDeviceServer::new(block_device.clone());
 
         let builder = device
-            .new_file(FileDescriptor { length: 4096 * 2 })
+            .new_file(FileDescriptor {
+                path: Path::test(),
+                length: 4096 * 2,
+            })
             .unwrap();
         let server = builder.build::<u8>();
 
@@ -68,6 +74,12 @@ mod legacy_tests {
 
         let device_data = block_device.data.lock();
 
-        assert_eq!(device_data[64..64 + 3], [42, 100, 200]);
+        // The CBOR encoding of 42, 100, 200
+        let data_bytes = [0x18, 0x2a, 0x18, 0x64, 0x18, 0xc8];
+        assert!(
+            device_data
+                .windows(data_bytes.len())
+                .any(|window| window == data_bytes)
+        );
     }
 }

--- a/kernel/comps/mariposa_data_capture/src/legacy/mod.rs
+++ b/kernel/comps/mariposa_data_capture/src/legacy/mod.rs
@@ -68,7 +68,7 @@ mod legacy_tests {
         sleep(Duration::from_millis(10));
 
         // Flush and give time for capture to complete
-        server.flush().unwrap();
+        server.sync().unwrap();
 
         sleep(Duration::from_millis(10));
 

--- a/kernel/comps/mariposa_data_capture/src/lib.rs
+++ b/kernel/comps/mariposa_data_capture/src/lib.rs
@@ -22,6 +22,12 @@
 //!
 //! The set of OQueue paths is only for convenience, so it can be incomplete or missing. This may be
 //! because of set of OQueues was not known when output started.
+//! 
+//! Note: The output format is not particularly space efficient because it includes the field names
+//! of structs every time they are serialized. If this becomes a problem there are a few options: 1)
+//! use [`#[serde(rename=...)`](https://serde.rs/field-attrs.html) to give shorter field names in
+//! the output, 2) explore using `serde_cbor`s [packed
+//! format](https://docs.rs/serde_cbor/latest/serde_cbor/struct.Serializer.html#method.packed_format).
 #![no_std]
 #![deny(unsafe_code)]
 
@@ -54,7 +60,7 @@ pub enum DataCaptureError {
     RPCError {
         source: ostd::orpc::errors::RPCError,
     },
-    #[snafu(display("Insufficient space on device or in file"))]
+    #[snafu(display("Insufficient space on device or in file ({context})"))]
     InsufficientSpaceError {},
     #[snafu(transparent)]
     IOError {

--- a/kernel/comps/mariposa_data_capture/src/lib.rs
+++ b/kernel/comps/mariposa_data_capture/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! The set of OQueue paths is only for convenience, so it can be incomplete or missing. This may be
 //! because of set of OQueues was not known when output started.
-//! 
+//!
 //! Note: The output format is not particularly space efficient because it includes the field names
 //! of structs every time they are serialized. If this becomes a problem there are a few options: 1)
 //! use [`#[serde(rename=...)`](https://serde.rs/field-attrs.html) to give shorter field names in

--- a/kernel/comps/mariposa_data_capture/src/lib.rs
+++ b/kernel/comps/mariposa_data_capture/src/lib.rs
@@ -10,22 +10,18 @@
 //! The format is a large raw file with blocks. Each block must be 4k page aligned and is in the
 //! following format:
 //! * The magic "number": `MARIPOSALDOSDATA` (null terminated).
-//! * A JSON object (null terminated):
+//! * A [CBOR](https://cbor.io/) object:
 //!     ```
-//!     { "oqueues": ["oqueue.path", ...], "type": "TypeName", "length": <block length in bytes> }
+//!     { "name": "file.path", "oqueues": ["oqueue.path", ...], "type_name": "TypeName" }
 //!     ```
 //!   The `oqueues` and `length` fields are optional.
-//! * 0 padding to a 64-byte boundary.
-//! * A packed series of [`binary_serde`] records serialized from type `TypeName`.
-//!
-//! The length makes it easier to find the next block and eliminates the (very very small) risk of
-//! randomly occuring magic numbers. However, it is not required.
+//! * A series of CBOR objects serialized from type `TypeName` using Serde. The CBOR objects are not
+//!   part of a list, instead just being concatinated. In Python, they can be read using repeated
+//!   calls to
+//!   [`cbor2.CBORDecoder.decode`](https://cbor2.readthedocs.io/en/latest/api.html#cbor2.CBORDecoder.decode).
 //!
 //! The set of OQueue paths is only for convenience, so it can be incomplete or missing. This may be
 //! because of set of OQueues was not known when output started.
-//!
-//! (Note: If you want to memory map the output file and read it directly, you should make sure that
-//! the serialized length of `TypeName` is a multiple of it's alignment.)
 #![no_std]
 #![deny(unsafe_code)]
 
@@ -46,6 +42,25 @@ pub use data_capture_file::{DataCaptureFile, DataCaptureFileBuilder, ObserverReg
 extern crate alloc;
 
 use component::{ComponentInitError, init_component};
+use ostd::ostd_error;
+use snafu::Snafu;
+
+#[non_exhaustive]
+#[ostd_error]
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum DataCaptureError {
+    #[snafu(transparent)]
+    RPCError {
+        source: ostd::orpc::errors::RPCError,
+    },
+    #[snafu(display("Insufficient space on device or in file"))]
+    InsufficientSpaceError {},
+    #[snafu(transparent)]
+    IOError {
+        source: aster_block::bio::BioEnqueueError,
+    },
+}
 
 #[init_component]
 fn init() -> Result<(), ComponentInitError> {
@@ -121,6 +136,12 @@ mod tests {
                 .any(|window| window == path_bytes)
         );
 
-        assert_eq!(device_data[64..64 + 3], [42, 100, 200]); // First value in first block
+        // The CBOR encoding of 42, 100, 200
+        let data_bytes = [0x18, 0x2a, 0x18, 0x64, 0x18, 0xc8];
+        assert!(
+            device_data
+                .windows(data_bytes.len())
+                .any(|window| window == data_bytes)
+        );
     }
 }

--- a/kernel/comps/mariposa_data_capture/src/lib.rs
+++ b/kernel/comps/mariposa_data_capture/src/lib.rs
@@ -123,7 +123,7 @@ mod tests {
         sleep(Duration::from_millis(10));
 
         // Flush and give time for capture to complete
-        server.flush().unwrap();
+        server.sync().unwrap();
 
         sleep(Duration::from_millis(10));
 

--- a/kernel/src/data_capture.rs
+++ b/kernel/src/data_capture.rs
@@ -3,11 +3,47 @@
 //! OQueue data capture utilities.
 
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::time::Duration;
 
-use log::info;
-use ostd::{ignore_err, sync::Mutex};
+use log::{error, info};
+use ostd::{
+    ignore_err, new_server,
+    orpc::{
+        framework::{notifier::Notifier as _, spawn_thread},
+        orpc_server,
+    },
+    sync::Mutex,
+};
 
-use crate::fs;
+use crate::{fs, kcmdline, util::timer::TimerServer};
+
+#[orpc_server]
+struct DataCaptureManager {}
+
+impl DataCaptureManager {
+    pub fn spawn(period: Duration) -> Arc<Self> {
+        let server = new_server!(|_| Self {});
+        spawn_thread(server.clone(), {
+            let server = server.clone();
+            move || server.main(period)
+        });
+        server
+    }
+
+    pub fn main(&self, period: Duration) -> Result<(), Box<dyn core::error::Error>> {
+        let notify_server = TimerServer::spawn(period);
+
+        let notify_observer = notify_server
+            .notification_oqueue()
+            .attach_strong_observer()?;
+        loop {
+            notify_observer.strong_observe();
+            for f in DATA_CAPTURE_FILE_SYNCERS.lock().iter() {
+                f();
+            }
+        }
+    }
+}
 
 static DATA_CAPTURE_DEVICE_LEGACY: Mutex<
     Option<Arc<dyn mariposa_data_capture::legacy::DataCaptureDevice>>,
@@ -19,21 +55,43 @@ static DATA_CAPTURE_DEVICE: Mutex<Option<Arc<dyn mariposa_data_capture::DataCapt
 pub(super) static DATA_CAPTURE_FILE_FINALIZERS: Mutex<Vec<Box<dyn Fn() + Send>>> =
     Mutex::new(Vec::new());
 
+static DATA_CAPTURE_FILE_SYNCERS: Mutex<Vec<Box<dyn Fn() + Send>>> = Mutex::new(Vec::new());
+
 pub(super) fn start_capture_devices() {
-    if let Ok(capture_block_device) = fs::start_block_device("capture_legacy") {
-        DATA_CAPTURE_DEVICE_LEGACY.lock().replace(
-            mariposa_data_capture::legacy::DataCaptureDeviceServer::new(capture_block_device),
-        );
-        info!("[kernel] Initialized legacy data capture device (capture_legacy)");
+    match fs::start_block_device("capture_legacy") {
+        Ok(capture_block_device) => {
+            DATA_CAPTURE_DEVICE_LEGACY.lock().replace(
+                mariposa_data_capture::legacy::DataCaptureDeviceServer::new(capture_block_device),
+            );
+            info!("[kernel] Initialized legacy data capture device (capture_legacy)");
+        }
+        Err(e) => error!(
+            "[kernel] Failed to initialize legacy data capture device (capture_legacy): {}",
+            e
+        ),
     }
 
-    if let Ok(capture_block_device) = fs::start_block_device("capture") {
-        DATA_CAPTURE_DEVICE
-            .lock()
-            .replace(mariposa_data_capture::DataCaptureDeviceServer::new(
-                capture_block_device,
-            ));
-        info!("[kernel] Initialized new data capture device (capture)");
+    match fs::start_block_device("capture") {
+        Ok(capture_block_device) => {
+            DATA_CAPTURE_DEVICE.lock().replace(
+                mariposa_data_capture::DataCaptureDeviceServer::new(capture_block_device),
+            );
+            info!("[kernel] Initialized new data capture device (capture)");
+        }
+        Err(e) => error!(
+            "[kernel] Failed to initialized new data capture device (capture): {}",
+            e
+        ),
+    }
+
+    // Start a server which syncs the data_capture devices every `secs` seconds based on the
+    // kcmdline arg `data_capture.sync_period`. If `data_capture.sync_period` is not provided or is
+    // <= 0, then do not sync periodically.
+    if let Some(secs) = kcmdline::get_kernel_cmd_line()
+        .and_then(|cl| cl.get_module_arg_by_name("data_capture", "sync_period"))
+        && secs > 0.0
+    {
+        DataCaptureManager::spawn(Duration::from_secs_f32(secs));
     }
 }
 
@@ -41,8 +99,9 @@ pub(super) fn start_capture_devices() {
 pub fn new_legacy_data_capture_file<T: serde::Serialize + Copy + Send + 'static>(
     descriptor: mariposa_data_capture::legacy::FileDescriptor,
 ) -> Arc<dyn mariposa_data_capture::legacy::DataCaptureFile<T>> {
-    let data_capture_device = DATA_CAPTURE_DEVICE_LEGACY.lock().clone();
-    let ret = data_capture_device
+    let ret = DATA_CAPTURE_DEVICE_LEGACY
+        .lock()
+        .as_ref()
         .unwrap()
         .new_file(descriptor)
         .unwrap()
@@ -51,6 +110,13 @@ pub fn new_legacy_data_capture_file<T: serde::Serialize + Copy + Send + 'static>
         let ret = ret.clone();
         move || {
             ignore_err!(ret.stop());
+            info!("[kernel] Stopped data capture device (capture)");
+        }
+    }));
+    DATA_CAPTURE_FILE_SYNCERS.lock().push(Box::new({
+        let ret = ret.clone();
+        move || {
+            ignore_err!(ret.sync());
             info!("[kernel] Sync'd data capture device (capture)");
         }
     }));
@@ -61,8 +127,9 @@ pub fn new_legacy_data_capture_file<T: serde::Serialize + Copy + Send + 'static>
 pub fn new_data_capture_file<T: serde::Serialize + Copy + Send + 'static>(
     descriptor: mariposa_data_capture::FileDescriptor,
 ) -> Arc<dyn mariposa_data_capture::DataCaptureFile<T>> {
-    let data_capture_device = DATA_CAPTURE_DEVICE.lock().clone();
-    let ret = data_capture_device
+    let ret = DATA_CAPTURE_DEVICE
+        .lock()
+        .as_ref()
         .unwrap()
         .new_file(descriptor)
         .unwrap()
@@ -71,6 +138,13 @@ pub fn new_data_capture_file<T: serde::Serialize + Copy + Send + 'static>(
         let ret = ret.clone();
         move || {
             ignore_err!(ret.stop());
+            info!("[kernel] Stopped legacy data capture device (capture_legacy)");
+        }
+    }));
+    DATA_CAPTURE_FILE_SYNCERS.lock().push(Box::new({
+        let ret = ret.clone();
+        move || {
+            ignore_err!(ret.sync());
             info!("[kernel] Sync'd legacy data capture device (capture_legacy)");
         }
     }));

--- a/kernel/src/data_capture.rs
+++ b/kernel/src/data_capture.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! OQueue data capture utilities.
+
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+
+use log::info;
+use ostd::{ignore_err, sync::Mutex};
+
+use crate::fs;
+
+static DATA_CAPTURE_DEVICE_LEGACY: Mutex<
+    Option<Arc<dyn mariposa_data_capture::legacy::DataCaptureDevice>>,
+> = Mutex::new(None);
+
+static DATA_CAPTURE_DEVICE: Mutex<Option<Arc<dyn mariposa_data_capture::DataCaptureDevice>>> =
+    Mutex::new(None);
+
+pub(super) static DATA_CAPTURE_FILE_FINALIZERS: Mutex<Vec<Box<dyn Fn() + Send>>> =
+    Mutex::new(Vec::new());
+
+pub(super) fn start_capture_devices() {
+    if let Ok(capture_block_device) = fs::start_block_device("capture_legacy") {
+        DATA_CAPTURE_DEVICE_LEGACY.lock().replace(
+            mariposa_data_capture::legacy::DataCaptureDeviceServer::new(capture_block_device),
+        );
+        info!("[kernel] Initialized legacy data capture device (capture_legacy)");
+    }
+
+    if let Ok(capture_block_device) = fs::start_block_device("capture") {
+        DATA_CAPTURE_DEVICE
+            .lock()
+            .replace(mariposa_data_capture::DataCaptureDeviceServer::new(
+                capture_block_device,
+            ));
+        info!("[kernel] Initialized new data capture device (capture)");
+    }
+}
+
+/// Create a new data capture file for legacy OQueues.
+pub fn new_legacy_data_capture_file<T: serde::Serialize + Copy + Send + 'static>(
+    descriptor: mariposa_data_capture::legacy::FileDescriptor,
+) -> Arc<dyn mariposa_data_capture::legacy::DataCaptureFile<T>> {
+    let data_capture_device = DATA_CAPTURE_DEVICE_LEGACY.lock().clone();
+    let ret = data_capture_device
+        .unwrap()
+        .new_file(descriptor)
+        .unwrap()
+        .build();
+    DATA_CAPTURE_FILE_FINALIZERS.lock().push(Box::new({
+        let ret = ret.clone();
+        move || {
+            ignore_err!(ret.stop());
+            info!("[kernel] Sync'd data capture device (capture)");
+        }
+    }));
+    ret
+}
+
+/// Create a new data capture file for OQueues.
+pub fn new_data_capture_file<T: serde::Serialize + Copy + Send + 'static>(
+    descriptor: mariposa_data_capture::FileDescriptor,
+) -> Arc<dyn mariposa_data_capture::DataCaptureFile<T>> {
+    let data_capture_device = DATA_CAPTURE_DEVICE.lock().clone();
+    let ret = data_capture_device
+        .unwrap()
+        .new_file(descriptor)
+        .unwrap()
+        .build();
+    DATA_CAPTURE_FILE_FINALIZERS.lock().push(Box::new({
+        let ret = ret.clone();
+        move || {
+            ignore_err!(ret.stop());
+            info!("[kernel] Sync'd legacy data capture device (capture_legacy)");
+        }
+    }));
+    ret
+}

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -37,7 +37,7 @@ use crate::{
 /// Start a thread of the block device to pop requests from the block device's
 /// request queue and process them if there are any. If the request queue is empty,
 /// the thread will wait until there is a request in the queue.
-fn start_block_device(device_name: &str) -> Result<Arc<dyn BlockDevice>> {
+pub(crate) fn start_block_device(device_name: &str) -> Result<Arc<dyn BlockDevice>> {
     if let Some(device) = aster_block::get_device(device_name) {
         let cloned_device = device.clone();
         let task_fn = move || {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -24,6 +24,10 @@
 #![register_tool(component_access_control)]
 
 use aster_framebuffer::FRAMEBUFFER_CONSOLE;
+#[cfg(not(baseline_asterinas))]
+mod data_capture;
+#[cfg(not(baseline_asterinas))]
+pub use data_capture::{new_data_capture_file, new_legacy_data_capture_file};
 use kcmdline::KCmdlineArg;
 use ostd::{
     arch::qemu::{QemuExitCode, exit_qemu},
@@ -159,6 +163,11 @@ fn init_thread() {
         .unwrap_or(false);
     set_huge_mapping_preserve_on_dontneed(huge_mapping_preserve_on_dontneed);
 
+    #[cfg(not(baseline_asterinas))]
+    {
+        data_capture::start_capture_devices();
+    }
+
     #[cfg(target_arch = "x86_64")]
     net::lazy_init();
     fs::lazy_init();
@@ -219,6 +228,11 @@ fn init_thread() {
     // Wait till initproc become zombie.
     while !initproc.status().is_zombie() {
         ostd::task::halt_cpu();
+    }
+
+    #[cfg(not(baseline_asterinas))]
+    for f in data_capture::DATA_CAPTURE_FILE_FINALIZERS.lock().drain(..) {
+        f();
     }
 
     // TODO: exit via qemu isa debug device should not be the only way.

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -43,6 +43,7 @@ bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 crossbeam-utils = { version = "0.8.21", default-features = false }
 tinyvec = { version = "1.10"}
 static_assertions = "*"
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"]}
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = "0.14.13"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+black==21.10b0
+cbor2==5.9
+pytest==9.0

--- a/test/Makefile
+++ b/test/Makefile
@@ -27,6 +27,7 @@ RAID1_IMAGE0 := $(BUILD_DIR)/raid1_0.img
 RAID1_IMAGE1 := $(BUILD_DIR)/raid1_1.img
 CAPTURE_IMAGE := $(BUILD_DIR)/capture.img
 CAPTURE_LEGACY_IMAGE := $(BUILD_DIR)/capture_legacy.img
+CAPTURE_IMAGE_SIZE := 4G
 
 INITRAMFS_EMPTY_DIRS := \
 	$(INITRAMFS)/root \
@@ -257,13 +258,13 @@ $(RAID1_IMAGE0) $(RAID1_IMAGE1):
 	@mke2fs $(RAID1_IMAGE0)
 	@dd if=$(RAID1_IMAGE0) of=$(RAID1_IMAGE1)
 
-# We use truncate for capture files because sparse allocation will improve performance and realistic
-# access times are not needed.
+# We use truncate for capture files because sparse allocation will save disk-space in the host, the
+# writes will mostly be cached in RAM, and realistic access times are not needed.
 $(CAPTURE_IMAGE):
-	@truncate -s 4G $@
+	truncate -s $(CAPTURE_IMAGE_SIZE) $@
 
 $(CAPTURE_LEGACY_IMAGE):
-	@truncate -s 4G $@
+	truncate -s $(CAPTURE_IMAGE_SIZE) $@
 
 .PHONY: build
 build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(RAID1_IMAGE0) $(RAID1_IMAGE1) $(CAPTURE_IMAGE) $(CAPTURE_LEGACY_IMAGE)

--- a/test/Makefile
+++ b/test/Makefile
@@ -25,6 +25,8 @@ EXT2_IMAGE := $(BUILD_DIR)/ext2.img
 EXFAT_IMAGE := $(BUILD_DIR)/exfat.img
 RAID1_IMAGE0 := $(BUILD_DIR)/raid1_0.img
 RAID1_IMAGE1 := $(BUILD_DIR)/raid1_1.img
+CAPTURE_IMAGE := $(BUILD_DIR)/capture.img
+CAPTURE_LEGACY_IMAGE := $(BUILD_DIR)/capture_legacy.img
 
 INITRAMFS_EMPTY_DIRS := \
 	$(INITRAMFS)/root \
@@ -255,8 +257,16 @@ $(RAID1_IMAGE0) $(RAID1_IMAGE1):
 	@mke2fs $(RAID1_IMAGE0)
 	@dd if=$(RAID1_IMAGE0) of=$(RAID1_IMAGE1)
 
+# We use truncate for capture files because sparse allocation will improve performance and realistic
+# access times are not needed.
+$(CAPTURE_IMAGE):
+	@truncate -s 4G $@
+
+$(CAPTURE_LEGACY_IMAGE):
+	@truncate -s 4G $@
+
 .PHONY: build
-build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(RAID1_IMAGE0) $(RAID1_IMAGE1)
+build: $(INITRAMFS_IMAGE) $(EXT2_IMAGE) $(EXFAT_IMAGE) $(RAID1_IMAGE0) $(RAID1_IMAGE1) $(CAPTURE_IMAGE) $(CAPTURE_LEGACY_IMAGE)
 
 .PHONY: format
 format:

--- a/tools/qemu_args.sh
+++ b/tools/qemu_args.sh
@@ -91,6 +91,8 @@ COMMON_QEMU_ARGS="\
     -drive if=none,format=raw,id=x1,file=./test/build/exfat.img \
     -drive if=none,format=raw,id=r0,file=./test/build/raid1_0.img,cache=directsync \
     -drive if=none,format=raw,id=r1,file=./test/build/raid1_1.img,cache=directsync \
+    -drive if=none,format=raw,id=d0,file=./test/build/capture.img \
+    -drive if=none,format=raw,id=d1,file=./test/build/capture_legacy.img \
 "
 
 if [ "$1" = "iommu" ]; then
@@ -113,6 +115,8 @@ QEMU_ARGS="\
     -device virtio-blk-pci,bus=pcie.0,addr=0x7,drive=x1,serial=vexfat,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
     -device virtio-blk-pci,bus=pcie.0,addr=0x8,drive=r0,serial=raid0,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
     -device virtio-blk-pci,bus=pcie.0,addr=0x9,drive=r1,serial=raid1,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+    -device virtio-blk-pci,bus=pcie.0,addr=0xa,drive=d0,serial=capture,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
+    -device virtio-blk-pci,bus=pcie.0,addr=0xb,drive=d1,serial=capture_legacy,disable-legacy=on,disable-modern=off,queue-size=64,num-queues=1,request-merging=off,backend_defaults=off,discard=off,write-zeroes=off,event_idx=off,indirect_desc=off,queue_reset=off$IOMMU_DEV_EXTRA \
     -device virtio-net-pci,netdev=net01,disable-legacy=on,disable-modern=off$VIRTIO_NET_FEATURES$IOMMU_DEV_EXTRA \
     -device virtio-serial-pci,disable-legacy=on,disable-modern=off$IOMMU_DEV_EXTRA \
     -device virtconsole,chardev=mux \
@@ -128,6 +132,8 @@ MICROVM_QEMU_ARGS="\
     -device virtio-blk-device,drive=x1,serial=vexfat \
     -device virtio-blk-device,drive=r0,serial=raid0 \
     -device virtio-blk-device,drive=r1,serial=raid1 \
+    -device virtio-blk-device,drive=d0,serial=capture \
+    -device virtio-blk-device,drive=d1,serial=capture_legacy \
     -device virtio-keyboard-device \
     -device virtio-net-device,netdev=net01 \
     -device virtio-serial-device \


### PR DESCRIPTION
This changes the data capture machinery:
* Use [CBOR](https://cbor.io/). It is a self describing format generally similar to JSON. This is selected not because the format is better than others, but because the Rust library supports no-std and is stable. I evaluated message pack, and BSON. CBOR has a Python implementation. Notably, we are not generating CBOR lists, instead we are generating a series of CBOR values directly into the file.
* Update the output format to include a CBOR-based directory of the files in the partition image.
* Added a global function to create new files within the output images. This is provided for both new and legacy OQueues.
* Run environment support for the above using 4G data files.
* A python library for reading the data generated by all the above.

AI USE: Claude for initial drafting of various parts.