### PR TITLE
Draft: Benchmark framework

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,33 @@
+# Benchmarking Framework
+
+Over time we want to track the performance of benchmarks as we continue to improve the system.
+
+## System Requirements
+
+- Produces trackable metrics per benchmark
+- Builds are hermetic
+- Benchmarks are easy to add
+- Metrics are easy to track
+
+## System Architecture
+
+```
+benchmarks
+├── flake.nix # This injects the state of what asterinas needs
+├── rocksdb # Folder per benchmark
+│   ├── flake.nix # Configuration for benchmark dependencies are inputs
+│   ├── inputs # Configuration for benchmark dependencies are inputs
+│   │   ├── small.sh # Defines a shell script for running -- use IN_ASTERINAS env var
+│   │   └── big.sh
+│   └── p90 # folder defines a trackable metric
+│       └── filter.awk # awk filter script
+└── ycsb-redis
+    ├── flake.nix
+    ├── inputs
+    │   ├── small.sh
+    │   └── big.sh
+    └── p90
+        └── filter.awk
+```
+
+We use nix because it's hermetic by design and so many of these benchmarks break as docker versions progress.

--- a/benchmarks/flake.lock
+++ b/benchmarks/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "libmemcached-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1391947053,
+        "narHash": "sha256-P7xOpEhWvSAq8B3vH0fNVCgI35RWgdxYzhcfhMNRcx0=",
+        "type": "tarball",
+        "url": "https://launchpad.net/libmemcached/1.0/1.0.18/%2Bdownload/libmemcached-1.0.18.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://launchpad.net/libmemcached/1.0/1.0.18/%2Bdownload/libmemcached-1.0.18.tar.gz"
+      }
+    },
+    "memcached-benchmark": {
+      "inputs": {
+        "libmemcached-src": [
+          "libmemcached-src"
+        ],
+        "memcached-src": [
+          "memcached-src"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "path": "./memcached",
+        "type": "path"
+      },
+      "original": {
+        "path": "./memcached",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "memcached-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1729462814,
+        "narHash": "sha256-6a2QScoCi0CmuN00lbdWi0Xyl1J+bS+jtohnDW0svhw=",
+        "type": "tarball",
+        "url": "https://memcached.org/files/memcached-1.6.32.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://memcached.org/files/memcached-1.6.32.tar.gz"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "libmemcached-src": "libmemcached-src",
+        "memcached-benchmark": "memcached-benchmark",
+        "memcached-src": "memcached-src",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/benchmarks/flake.nix
+++ b/benchmarks/flake.nix
@@ -1,0 +1,64 @@
+{
+  description = "Asterinas benchmark container images";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # Authoritative source versions — match tools/docker/Dockerfile exactly.
+    # Injected into each benchmark sub-flake via follows so versions are
+    # declared in exactly one place.
+    memcached-src = {
+      url = "https://memcached.org/files/memcached-1.6.32.tar.gz";
+      flake = false;
+    };
+
+    libmemcached-src = {
+      url = "https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz";
+      flake = false;
+    };
+
+    memcached-benchmark = {
+      url = "path:./memcached";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.memcached-src.follows = "memcached-src";
+      inputs.libmemcached-src.follows = "libmemcached-src";
+    };
+  };
+
+  outputs = { self, nixpkgs, memcached-benchmark, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      memcachedPkgs = memcached-benchmark.packages.${system};
+
+      # Base image used by `make docker` — version comes from DOCKER_IMAGE_VERSION.
+      # After a version bump, update imageDigest and sha256 by running:
+      #   nix-prefetch-docker --imageName ldosproject/asterinas \
+      #                       --imageTag 0.15.2-20250613
+      baseImage = pkgs.dockerTools.pullImage {
+        imageName    = "ldosproject/asterinas";
+        finalImageTag = "0.15.2-20250613";
+        imageDigest  = "sha256:3cb56ee8fccfaf1924f04fe2895f4471feb8ff6adc8c05dfed872c444d7904bc";
+        sha256       = "sha256-rEFAT5t/A8kU9SAtrCKHwImcFslvKVjnhlbUfob2SEU=";
+      };
+    in {
+      packages.${system} = {
+
+        memcached = pkgs.dockerTools.buildLayeredImage {
+          name = "ldosproject/asterinas";
+          tag  = "benchmark-memcached";
+
+          # Layer on top of the exact image that `make docker` uses, so all
+          # system libraries (glibc, libevent, etc.) match the Dockerfile.
+          fromImage = baseImage;
+
+          # Both packages land in the nix store inside the container.
+          # test/Makefile will be updated to pull from their store paths directly.
+          contents = [ memcachedPkgs.memcached memcachedPkgs.memaslap ];
+
+          config.Cmd = [ "/usr/bin/bash" ];
+        };
+
+      };
+    };
+}

--- a/benchmarks/memcached/flake.nix
+++ b/benchmarks/memcached/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "Memcached benchmark — server (guest) and memaslap client (host)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    memcached-src = {
+      url = "https://memcached.org/files/memcached-1.6.32.tar.gz"; # version: 1.6.32
+      flake = false;
+    };
+
+    libmemcached-src = {
+      url = "https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz"; # version: 1.0.18
+      flake = false;
+    };
+  };
+
+  outputs = { nixpkgs, memcached-src, libmemcached-src, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      # Versions are kept as comments on the input URLs above; update both together.
+      memcachedVersion    = "1.6.32";
+      libmemcachedVersion = "1.0.18";
+
+      packages = {
+
+        # memcached server — runs inside the Asterinas guest via initramfs.
+        # Built statically (musl) so it has no dynamic library dependencies;
+        # the nix store is not present in the Asterinas guest environment.
+        memcached = pkgs.pkgsStatic.memcached.overrideAttrs (_old: {
+          version = memcachedVersion;
+          src = memcached-src;
+        });
+
+        # memaslap benchmark client — runs on the host.
+        # Build mirrors tools/docker/Dockerfile: autotools, --enable-memaslap,
+        # -fcommon/-fpermissive workarounds for the old 1.0.18 codebase.
+        memaslap = pkgs.stdenv.mkDerivation {
+          pname = "memaslap";
+          version = libmemcachedVersion;
+          src = libmemcached-src;
+
+          nativeBuildInputs = with pkgs; [ pkg-config ];
+          buildInputs = with pkgs; [ libevent cyrus_sasl ];
+
+          CFLAGS   = "-fpermissive -fcommon";
+          CPPFLAGS = "-fcommon -fpermissive";
+          LDFLAGS  = "-lpthread";
+
+          configureFlags = [ "--enable-memaslap" ];
+
+          # Dockerfile overrides CPPFLAGS for the make step (drops -fpermissive).
+          preBuild = "export CPPFLAGS=-fcommon";
+
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 clients/memaslap $out/bin/memaslap
+            runHook postInstall
+          '';
+        };
+
+      };
+    in {
+      packages.${system}      = packages;
+      defaultPackage.${system} = packages.memcached;
+    };
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -132,7 +132,8 @@ $(INITRAMFS)/usr/local:
 	@mkdir -p $@
 	@cp -r /usr/local/nginx $@
 	@cp -r /usr/local/redis $@
-	@cp -r /usr/local/memcached $@
+	@mkdir -p $@/memcached/bin
+	@cp -L $$(which memcached) $@/memcached/bin/memcached
 
 .PHONY: $(INITRAMFS)/test
 $(INITRAMFS)/test:

--- a/test/benchmark/memcached/t16_conc64_window10k/host.sh
+++ b/test/benchmark/memcached/t16_conc64_window10k/host.sh
@@ -16,6 +16,6 @@ trap stop_guest EXIT
 
 # Run memaslap bench
 echo "Running memaslap bench connected to $GUEST_SERVER_IP_ADDRESS"
-/usr/local/benchmark/libmemcached/bin/memaslap -s $GUEST_SERVER_IP_ADDRESS:11211 -t 30s -T 16 -c 64 -w 10k -S 1s
+memaslap -s $GUEST_SERVER_IP_ADDRESS:11211 -t 30s -T 16 -c 64 -w 10k -S 1s
 
 # The trap will automatically stop the guest VM when the script exits

--- a/test/benchmark/memcached/t8_conc32_window10k/host.sh
+++ b/test/benchmark/memcached/t8_conc32_window10k/host.sh
@@ -17,6 +17,6 @@ trap stop_guest EXIT
 # Run memaslap bench
 echo "Running memaslap bench connected to $GUEST_SERVER_IP_ADDRESS"
 # -S 1s: Dump statistic information every second
-/usr/local/benchmark/libmemcached/bin/memaslap -s $GUEST_SERVER_IP_ADDRESS:11211 -t 30s -T 8 -c 32 -w 10k -S 1s
+memaslap -s $GUEST_SERVER_IP_ADDRESS:11211 -t 30s -T 8 -c 32 -w 10k -S 1s
 
 # The trap will automatically stop the guest VM when the script exits

--- a/test/benchmark/memcached/t8_conc32_window20k/host.sh
+++ b/test/benchmark/memcached/t8_conc32_window20k/host.sh
@@ -17,6 +17,6 @@ trap stop_guest EXIT
 # Run memaslap bench
 echo "Running memaslap bench connected to $GUEST_SERVER_IP_ADDRESS"
 # -S 1s: Dump statistic information every second
-/usr/local/benchmark/libmemcached/bin/memaslap -s $GUEST_SERVER_IP_ADDRESS:11211 -t 30s -T 8 -c 32 -w 20k -S 1s
+memaslap -s $GUEST_SERVER_IP_ADDRESS:11211 -t 30s -T 8 -c 32 -w 20k -S 1s
 
 # The trap will automatically stop the guest VM when the script exits


### PR DESCRIPTION
This PR has the docs to define the benchmarking framework. please see benchmarks/README.md for more information.

It still requires significant cleanup but things are working. Overtime the full docker hermetic configuration will make it into benchmarks/flake.nix and things will get more stable.