### PR TITLE
Add support for selecting a subset of gVisor tests

### DIFF
--- a/docs/src/kernel/advanced-instructions.md
+++ b/docs/src/kernel/advanced-instructions.md
@@ -48,6 +48,16 @@ The following command builds and runs the syscall test binaries on Asterinas.
 make run AUTO_TEST=syscall
 ```
 
+To select a subset of the gVisor tests, pass test blocklist file name to the test runner script. For
+example:
+
+```bash
+make run AUTO_TEST=syscall SYSCALL_TEST_SUITE=gvisor INITARGS="futex_test"
+```
+
+(See comment in the launcher script, `test/syscall_test/gvisor/run_gvisor_test.sh`, for more information.)
+(TODO(arthurp): This is not available for LTP tests.)
+
 To run system call tests interactively, start an instance of Asterinas with the system call tests built and installed.
 
 ```bash

--- a/test/syscall_test/gvisor/run_gvisor_test.sh
+++ b/test/syscall_test/gvisor/run_gvisor_test.sh
@@ -2,6 +2,22 @@
 
 # SPDX-License-Identifier: MPL-2.0
 
+# Run gVisor syscall tests.
+#
+# Usage: run_gvisor_test.sh [TEST_NAME...]
+#
+# If no arguments are given, all tests are run. If TEST_NAME arguments are given, only those test
+# binaries are run (matched exactly, e.g. "futex_test"). They are run with the same configuration as
+# this script otherwise would, so the configuration (e.g.,
+# `test/syscall_test/gvisor/blocklists/futex_test`) will still apply.
+#
+# To run a subset of tests via the `make run`, pass the test names through INITARGS:
+#
+#   make run AUTO_TEST=syscall SYSCALL_TEST_SUITE=gvisor INITARGS="futex_test"
+#   make run AUTO_TEST=syscall SYSCALL_TEST_SUITE=gvisor INITARGS="futex_test socket_test"
+
+# TODO: This should probably allow passing full test selectors as passed to --gtest_filter.
+
 SCRIPT_DIR=$(dirname "$0")
 TEST_TMP_DIR=${SYSCALL_TEST_WORKDIR:-/tmp}
 TEST_BIN_DIR=$SCRIPT_DIR/tests
@@ -53,7 +69,14 @@ run_one_test(){
 rm -f $FAIL_CASES && touch $FAIL_CASES
 rm -rf $TEST_TMP_DIR/*
 
-for syscall_test in $(find $TEST_BIN_DIR/. -name \*_test) ; do
+# Create test list based on arguments
+if [ $# -gt 0 ]; then
+    tests="$*"
+else
+    tests="$(find $TEST_BIN_DIR/. -name \*_test)"
+fi
+
+for syscall_test in  "$tests" ; do
     test_name=$(basename "$syscall_test")
     run_one_test $test_name
     if [ $? -eq 0 ] && PASSED_TESTS=$((PASSED_TESTS+1));then

--- a/test/syscall_test/run_syscall_test.sh
+++ b/test/syscall_test/run_syscall_test.sh
@@ -10,13 +10,13 @@ GVISOR_DIR=/opt/gvisor
 
 if [ "${SYSCALL_TEST_SUITE}" == "ltp" ]; then
     echo "Running LTP syscall tests..."
-    if ! "${LTP_DIR}/run_ltp_test.sh"; then
+    if ! "${LTP_DIR}/run_ltp_test.sh" "$@"; then
         echo "Error: LTP syscall tests failed." >&2
         exit 1
     fi
 elif [ "${SYSCALL_TEST_SUITE}" == "gvisor" ]; then
     echo "Running gVisor syscall tests..."
-    if ! "${GVISOR_DIR}/run_gvisor_test.sh"; then
+    if ! "${GVISOR_DIR}/run_gvisor_test.sh" "$@"; then
         echo "Error: gVisor syscall tests failed." >&2
         exit 2
     fi


### PR DESCRIPTION
This does NOT enable the same feature for LTP. Problems with it's launcher prevented an easy way to do it, and the LTP is out of date, so a correct solution will wait until/if we update.

AI USE: Claude for initial draft of change.