### PR TITLE
Replace core2 with no_std_io2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,6 @@ dependencies = [
  "cfg-if",
  "component",
  "controlled",
- "core2",
  "cpio-decoder",
  "crossbeam-utils",
  "fixed",
@@ -240,6 +239,7 @@ dependencies = [
  "log",
  "lru",
  "mariposa_data_capture",
+ "no_std_io2",
  "osdk-frame-allocator",
  "osdk-heap-allocator",
  "ostd",
@@ -538,21 +538,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpio-decoder"
 version = "0.1.0"
 dependencies = [
- "core2",
  "int-to-c-enum",
  "lending-iterator",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -776,6 +767,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "font8x8"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,7 +886,18 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1064,25 +1072,25 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libflate"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
 dependencies = [
  "adler32",
- "core2",
  "crc32fast",
  "dary_heap",
  "libflate_lz77",
+ "no_std_io2",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
- "core2",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
+ "no_std_io2",
  "rle-decode-fast",
 ]
 
@@ -1107,10 +1115,10 @@ name = "linux-bzimage-setup"
 version = "0.15.2"
 dependencies = [
  "cfg-if",
- "core2",
  "libflate",
  "linux-boot-params",
  "log",
+ "no_std_io2",
  "tdx-guest",
  "uart_16550",
  "uefi",
@@ -1222,6 +1230,15 @@ name = "never-say-never"
 version = "6.6.666"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nougat"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -48,8 +48,8 @@ xmas-elf = "0.10.0"
 bitflags = "1.3"
 keyable-arc = { path = "libs/keyable-arc" }
 # unzip initramfs
-libflate = { version = "2", default-features = false }
-core2 = { version = "0.4", default-features = false, features = ["alloc"] }
+libflate = { version = "2.3", default-features = false }
+no_std_io2 = { version = "0.9.3", features = ["alloc"] }
 lending-iterator = "0.1.7"
 spin = "0.9.4"
 lru = "0.12.3"

--- a/kernel/libs/cpio-decoder/Cargo.toml
+++ b/kernel/libs/cpio-decoder/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
-core2 = { version = "0.4", default-features = false, features = ["alloc"] }
+no_std_io2 = { version = "0.9.3", features = ["alloc"] }
 lending-iterator = "0.1.7"
 
 [lints]

--- a/kernel/libs/cpio-decoder/src/error.rs
+++ b/kernel/libs/cpio-decoder/src/error.rs
@@ -14,10 +14,10 @@ pub enum Error {
     IoError,
 }
 
-impl From<core2::io::Error> for Error {
+impl From<no_std_io2::io::Error> for Error {
     #[inline]
-    fn from(err: core2::io::Error) -> Self {
-        use core2::io::ErrorKind;
+    fn from(err: no_std_io2::io::Error) -> Self {
+        use no_std_io2::io::ErrorKind;
 
         match err.kind() {
             ErrorKind::UnexpectedEof => Self::BufferShortError,

--- a/kernel/libs/cpio-decoder/src/lib.rs
+++ b/kernel/libs/cpio-decoder/src/lib.rs
@@ -26,9 +26,9 @@ use alloc::{
 };
 use core::cmp::min;
 
-use core2::io::{Read, Write};
 use int_to_c_enum::TryFromInt;
 use lending_iterator::prelude::*;
+use no_std_io2::io::{Read, Write};
 
 use crate::error::{Error, Result};
 

--- a/kernel/src/fs/rootfs.rs
+++ b/kernel/src/fs/rootfs.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use core2::io::{Cursor, Read};
 use cpio_decoder::{CpioDecoder, FileType};
 use lending_iterator::LendingIterator;
 use libflate::gzip::Decoder as GZipDecoder;
+use no_std_io2::io::{Cursor, Read};
 use spin::Once;
 
 use super::{
@@ -25,7 +25,7 @@ impl<'a> BoxedReader<'a> {
 }
 
 impl Read for BoxedReader<'_> {
-    fn read(&mut self, buf: &mut [u8]) -> core2::io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> no_std_io2::io::Result<usize> {
         self.0.read(buf)
     }
 }

--- a/kernel/src/fs/utils/inode.rs
+++ b/kernel/src/fs/utils/inode.rs
@@ -5,7 +5,7 @@
 use core::{any::TypeId, time::Duration};
 
 use aster_rights::Full;
-use core2::io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult, Write};
+use no_std_io2::io::{Error as IoError, ErrorKind as IoErrorKind, Result as IoResult, Write};
 use ostd::task::Task;
 
 use super::{

--- a/osdk/Cargo.lock
+++ b/osdk/Cargo.lock
@@ -302,15 +302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,16 +431,23 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -592,25 +596,25 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libflate"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
 dependencies = [
  "adler32",
- "core2",
  "crc32fast",
  "dary_heap",
  "libflate_lz77",
+ "no_std_io2",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
- "core2",
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
+ "no_std_io2",
  "rle-decode-fast",
 ]
 
@@ -653,6 +657,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "num-format"

--- a/ostd/libs/linux-bzimage/builder/Cargo.toml
+++ b/ostd/libs/linux-bzimage/builder/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/ldos-project/asterinas"
 align_ext = { version = "0.1.0", path = "../../align_ext" }
 bitflags = "1.3"
 bytemuck = { version = "1.17.0", features = ["derive"] }
-libflate = "2.1.0"
+libflate = "2.3.0"
 serde = { version = "1.0.192", features = ["derive"] }
 xmas-elf = "0.10.0"
 

--- a/ostd/libs/linux-bzimage/setup/Cargo.toml
+++ b/ostd/libs/linux-bzimage/setup/Cargo.toml
@@ -13,14 +13,14 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(target_os = "none")'.dependencies]
-core2 = { version = "0.4.0", default-features = false, features = ["nightly"] }
+no_std_io2 = { version = "0.9.3", default-features = false }
 
 [target.'cfg(not(target_os = "none"))'.dependencies]
-core2 = { version = "0.4.0", default-features = false }
+no_std_io2 = { version = "0.9.3", default-features = false }
 
 [dependencies]
 cfg-if = "1.0.0"
-libflate = { version = "2.1.0", default-features = false }
+libflate = { version = "2.3.0", default-features = false }
 linux-boot-params = { version = "0.15.2", path = "../boot-params" }
 uart_16550 = "0.3.0"
 xmas-elf = "0.10.0"

--- a/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/decoder.rs
+++ b/ostd/libs/linux-bzimage/setup/src/x86/amd64_efi/decoder.rs
@@ -7,8 +7,8 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 
-use core2::io::Read;
 use libflate::{gzip, zlib};
+use no_std_io2::io::Read;
 
 enum MagicNumber {
     Elf,


### PR DESCRIPTION
This removes our dependency on core2 and replaces it with no_std_io2.

Initially there was an upstream issue with `libflate` carrying a core2 dependency, but `libflate` fixed that with a new 2.3 release.