### PR TITLE
Support capturing scheduling events into an OQueue and into data files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ dependencies = [
  "component",
  "log",
  "ostd",
+ "serde",
  "spin",
 ]
 

--- a/docs/src/ostd/data-capture.md
+++ b/docs/src/ostd/data-capture.md
@@ -1,0 +1,15 @@
+# Data OQueues available in OSTD
+
+## Scheduler
+
+Scheduling events can placed on an OQueue. Unlike most OQueues, this is disabled by default, because
+of the potential for unknown overhead in a very sensitive part of the system. It can be enabled with
+the `capture_scheduling` feature. You can enable this feature with `--features
+ostd/capture_scheduling` on the `cargo osdk` command line. (Or the
+`FEATURES=ostd/capture_scheduling` environment variable for OSTDs own makefiles.)
+
+(NOTE: Once we are confident that the overhead is low enough, `capture_scheduling` will be enabled
+by default.)
+
+To have the the Mariposa kernel capture the scheduling events to a file, add this *and* the kernel
+command line argument `scheduler.capture_data=true`.

--- a/kernel/comps/time/Cargo.toml
+++ b/kernel/comps/time/Cargo.toml
@@ -11,6 +11,7 @@ aster-util = { path = "../../libs/aster-util" }
 component = { path = "../../libs/comp-sys/component" }
 log = "0.4"
 spin = "0.9.4"
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"]}
 
 [target.riscv64gc-unknown-none-elf.dependencies]
 chrono = { version = "0.4.38", default-features = false }

--- a/kernel/comps/time/src/clocksource.rs
+++ b/kernel/comps/time/src/clocksource.rs
@@ -15,6 +15,7 @@ use core::{cmp::max, ops::Add, time::Duration};
 
 use aster_util::coeff::Coeff;
 use ostd::sync::{LocalIrqDisabled, RwLock};
+use serde::Serialize;
 
 use crate::NANOS_PER_SECOND;
 
@@ -172,7 +173,7 @@ impl ClockSource {
 /// elapsed since a reference point (typically the system boot time).
 /// The [`Instant`] is expressed in seconds and the fractional part is
 /// expressed in nanoseconds.
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone, Serialize)]
 pub struct Instant {
     secs: u64,
     nanos: u32,

--- a/kernel/src/event.rs
+++ b/kernel/src/event.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_time::Instant;
+use ostd::task::Task;
+use serde::Serialize;
+
+use crate::{process::posix_thread::AsPosixThread as _, thread::Tid};
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum TaskId {
+    KernelTask(usize),
+    PosixThread(Tid),
+    Unknown,
+}
+
+impl TaskId {
+    pub fn new(task: &Task) -> Self {
+        if let Some(t) = task.as_posix_thread() {
+            Self::PosixThread(t.tid())
+        } else {
+            Self::KernelTask(task.id().into())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct EventContext {
+    pub task: TaskId,
+    pub timestamp: Instant,
+}
+
+impl EventContext {
+    /// Creates a new EventContext from the current context
+    pub fn new() -> Self {
+        EventContext {
+            task: Task::current()
+                .map(|t| TaskId::new(&t))
+                .unwrap_or(TaskId::Unknown),
+            timestamp: aster_time::read_monotonic_time().into(),
+        }
+    }
+}
+
+impl Default for EventContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -26,19 +26,32 @@
 use aster_framebuffer::FRAMEBUFFER_CONSOLE;
 #[cfg(not(baseline_asterinas))]
 mod data_capture;
+pub mod event;
+use aster_time::Instant;
 #[cfg(not(baseline_asterinas))]
 pub use data_capture::{new_data_capture_file, new_legacy_data_capture_file};
 use kcmdline::KCmdlineArg;
+#[cfg(not(baseline_asterinas))]
+use mariposa_data_capture::ObserverRegistration;
 use ostd::{
     arch::qemu::{QemuExitCode, exit_qemu},
     boot::boot_info,
     cpu::{CpuId, CpuSet},
+    ignore_err,
+    task::scheduler::{SchedulingEvent, SchedulingEventKind},
+};
+#[cfg(not(baseline_asterinas))]
+use ostd::{
+    orpc::oqueue::{OQueueBase as _, ObservationQuery, registry::lookup_by_path},
+    path,
 };
 use process::{Process, spawn_init_process};
 use sched::SchedPolicy;
+use serde::Serialize;
 use spin::Once;
 
 use crate::{
+    event::{EventContext, TaskId},
     kcmdline::set_kernel_cmd_line,
     prelude::*,
     thread::kernel_thread::ThreadOptions,
@@ -223,6 +236,47 @@ fn init_thread() {
         let pmu = arch::pmu::PmuServer::spawn();
         pmu.reset();
         pmu.start();
+    }
+
+    #[cfg(not(baseline_asterinas))]
+    if karg
+        .get_module_arg_by_name::<bool>("scheduler", "capture_data")
+        .unwrap_or(false)
+    {
+        if let Some(oqueue) = lookup_by_path::<SchedulingEvent>(&path!(scheduler.events)) {
+            #[derive(Debug, Clone, Copy, Serialize)]
+            struct KernelSchedulingEvent {
+                timestamp: Instant,
+                task: TaskId,
+                kind: SchedulingEventKind,
+            }
+
+            let capture_file = new_data_capture_file::<KernelSchedulingEvent>(
+                mariposa_data_capture::FileDescriptor {
+                    path: path!(scheduler.events),
+                    length: 500 * 1024 * 1024,
+                },
+            );
+
+            ignore_err!(
+                capture_file.register_observer(ObserverRegistration {
+                    path: path!(scheduler.events),
+                    observer: oqueue
+                        .attach_strong_observer(ObservationQuery::new(|e: &SchedulingEvent| {
+                            let context = EventContext::new();
+                            KernelSchedulingEvent {
+                                timestamp: context.timestamp,
+                                kind: e.kind,
+                                task: TaskId::new(&e.task),
+                            }
+                        }))
+                        .unwrap(),
+                })
+            );
+            ignore_err!(capture_file.start());
+        } else {
+            error!("Could not find scheduler.events OQueue. Scheduler events will not be captured.")
+        }
     }
 
     // Wait till initproc become zombie.

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -66,6 +66,7 @@ fdt = { version = "0.1.5", features = ["pretty-printing"] }
 default = ["cvm_guest"]
 capture_stacks = []
 track_mutex = []
+capture_scheduling = []
 # The guest OS support for Confidential VMs (CVMs), e.g., Intel TDX
 cvm_guest = ["dep:tdx-guest", "dep:iced-x86"]
 

--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -138,6 +138,8 @@ unsafe fn init() {
 
     bus::init();
 
+    task::scheduler::init();
+
     arch::irq::enable_local();
 
     invoke_ffi_init_funcs();

--- a/ostd/src/task/scheduler/mod.rs
+++ b/ostd/src/task/scheduler/mod.rs
@@ -10,15 +10,44 @@ pub mod info;
 
 use core::time::Duration;
 
+use serde::Serialize;
 use spin::Once;
 
 use super::{Task, preempt::cpu_local, processor};
+#[cfg(feature = "capture_scheduling")]
+use crate::orpc::oqueue::RefProducer;
 use crate::{
     cpu::{CpuId, CpuSet, PinCurrentCpu},
     prelude::*,
     task::disable_preempt,
     timer,
 };
+
+/// Initialize scheduler globals.
+/// 
+/// This should be called before the scheduler runs for the first time, but after the allocator is
+/// fully initialized.
+pub(crate) fn init() {
+    #[cfg(feature = "capture_scheduling")]
+    SCHEDULING_EVENT_PRODUCER.call_once(|| {
+        use crate::{orpc::oqueue::{OQueue, OQueueRef}, path};
+
+        // TODO(arthurp): This calls the OQueue constructor before the scheduler is running. This is
+        // probably safe, but we should have documentation on when and why this is allowed.
+        let oqueue = OQueueRef::new(1024, path!(scheduler.events));
+        oqueue.attach_ref_producer().unwrap()
+    });
+}
+
+#[cfg(feature = "capture_scheduling")]
+static SCHEDULING_EVENT_PRODUCER: Once<RefProducer<SchedulingEvent>> = Once::new();
+
+/// Get the producer handle for the scheduling event OQueue. This will panic if called before
+/// [`init()`].
+#[cfg(feature = "capture_scheduling")]
+fn get_scheduling_event_producer() -> &'static crate::orpc::oqueue::RefProducer<SchedulingEvent> {
+    SCHEDULING_EVENT_PRODUCER.get().unwrap()
+}
 
 /// Injects a scheduler implementation into framework.
 ///
@@ -36,6 +65,24 @@ pub fn inject_scheduler(scheduler: &'static dyn Scheduler<Task>) {
 }
 
 static SCHEDULER: Once<&'static dyn Scheduler<Task>> = Once::new();
+
+/// An event either or scheduling or descheduling a task.
+#[derive(Debug)]
+pub struct SchedulingEvent {
+    /// The task
+    pub task: Arc<Task>,
+    /// The kind of event
+    pub kind: SchedulingEventKind,
+}
+
+/// The kind of a [`SchedulingEvent`].
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum SchedulingEventKind {
+    /// The task is about to start executing.
+    Schedule,
+    /// The task has stopped executing.
+    Deschedule,
+}
 
 /// A per-CPU task scheduler.
 pub trait Scheduler<T = Task>: Sync + Send {
@@ -268,6 +315,26 @@ where
                 break next_task;
             }
         };
+    };
+
+    // This redefines `next_task` with the same value it started with, but moves the value out
+    // temporarily. This avoids an atomic incr and decr.
+    #[cfg(feature = "capture_scheduling")]
+    let next_task = {
+        let producer = get_scheduling_event_producer();
+        if let Some(t) = Task::current() {
+            producer.produce_ref(&SchedulingEvent {
+                task: t.cloned(),
+                kind: SchedulingEventKind::Deschedule,
+            });
+        }
+
+        let scheduling_event = SchedulingEvent {
+            task: next_task,
+            kind: SchedulingEventKind::Schedule,
+        };
+        producer.produce_ref(&scheduling_event);
+        scheduling_event.task
     };
 
     // `switch_to_task` will spin if it finds that the next task is still running on some CPU core,

--- a/ostd/src/task/scheduler/mod.rs
+++ b/ostd/src/task/scheduler/mod.rs
@@ -24,13 +24,16 @@ use crate::{
 };
 
 /// Initialize scheduler globals.
-/// 
+///
 /// This should be called before the scheduler runs for the first time, but after the allocator is
 /// fully initialized.
 pub(crate) fn init() {
     #[cfg(feature = "capture_scheduling")]
     SCHEDULING_EVENT_PRODUCER.call_once(|| {
-        use crate::{orpc::oqueue::{OQueue, OQueueRef}, path};
+        use crate::{
+            orpc::oqueue::{OQueue, OQueueRef},
+            path,
+        };
 
         // TODO(arthurp): This calls the OQueue constructor before the scheduler is running. This is
         // probably safe, but we should have documentation on when and why this is allowed.


### PR DESCRIPTION
This adds a scheduling event OQueue and support for capturing it. Unlike most OQueues this one must be enabled by a feature. See the documentation file.

AFTER: #206 