### PR TITLE
Add context to error display

### DIFF
--- a/kernel/comps/mariposa_data_capture/src/data_capture_device.rs
+++ b/kernel/comps/mariposa_data_capture/src/data_capture_device.rs
@@ -32,7 +32,7 @@ pub struct FileDescriptor {
 pub enum DataCaptureDeviceError {
     #[snafu(transparent)]
     RPCError { source: RPCError },
-    #[snafu(display("Insufficient space on device"))]
+    #[snafu(display("Insufficient space on device ({context})"))]
     InsufficientSpace {},
 }
 

--- a/kernel/comps/mariposa_data_capture/src/legacy/data_capture_device.rs
+++ b/kernel/comps/mariposa_data_capture/src/legacy/data_capture_device.rs
@@ -30,7 +30,7 @@ pub struct FileDescriptor {
 pub enum DataCaptureDeviceError {
     #[snafu(transparent)]
     RPCError { source: RPCError },
-    #[snafu(display("Insufficient space on device"))]
+    #[snafu(display("Insufficient space on device ({context})"))]
     InsufficientSpace {},
 }
 

--- a/ostd/src/error.rs
+++ b/ostd/src/error.rs
@@ -24,22 +24,31 @@ pub trait OstdError: snafu::Error {
 #[snafu(visibility(pub))]
 pub enum Error {
     /// Invalid arguments provided.
+    #[snafu(display("Invalid arguments ({context})"))]
     InvalidArgs,
     /// Insufficient memory available.
+    #[snafu(display("Insufficient memory ({context})"))]
     NoMemory,
     /// Page fault occurred.
+    #[snafu(display("Page fault ({context})"))]
     PageFault,
     /// Access to a resource is denied.
+    #[snafu(display("Access denied ({context})"))]
     AccessDenied,
     /// Input/output error.
+    #[snafu(display("Input/output error ({context})"))]
     IoError,
     /// Insufficient system resources.
+    #[snafu(display("Insufficient resources ({context})"))]
     NotEnoughResources,
     /// Arithmetic Overflow occurred.
+    #[snafu(display("Arithmetic overflow ({context})"))]
     Overflow,
     /// Memory mapping already exists for the given virtual address.
+    #[snafu(display("Memory mapping already exists for this virtual address ({context})"))]
     MapAlreadyMappedVaddr,
     /// Error when allocating kernel virtual memory.
+    #[snafu(display("Error allocating kernel virtual memory ({context})"))]
     KVirtAreaAllocError,
     /// A ORPC error
     #[snafu(transparent)]

--- a/ostd/src/orpc/oqueue/mod.rs
+++ b/ostd/src/orpc/oqueue/mod.rs
@@ -92,17 +92,18 @@ pub enum OQueueError {
     /// The handle has been detached. Once this is returned, all future operations will return
     /// it. This can happen because access has been revoked (for instance, due to the observer
     /// being too slow), or the OQueue has been deleted.
+    #[snafu(display("Handle detached ({context})"))]
     Detached,
-
     /// The operation is supported by this OQueue but the required resources are missing (e.g.,
     /// observer slots or memory).
+    #[snafu(display("Resource unavailable ({context})"))]
     ResourceUnavailable,
-
     /// The operation is not supported or not allowed by this OQueue. An operation may not be
     /// supported if, for example, the OQueue does not support consumers and a client tries to
     /// attach one. An operation may also be disallowed to prevent problems such as potential hangs
     /// or crashes. For example, strong observers may not be allowed on an OQueue to prevent
     /// `produce` from blocking.
+    #[snafu(display("Operation unsupported or disallowed ({context})"))]
     Unsupported,
 }
 

--- a/ostd/src/orpc_common/errors.rs
+++ b/ostd/src/orpc_common/errors.rs
@@ -21,13 +21,13 @@ use crate::prelude::Box;
 pub enum RPCError {
     /// A panic occurred in the server during the call. The panic payload will be converted to a string, if possible. If
     /// it cannot be, then the string will be a generic error message.
-    #[snafu(display("{message}"))]
+    #[snafu(display("{message} ({context})"))]
     Panic {
         /// message associated with this panic
         message: String,
     },
     /// The server does not exist or is not running. This can happen when a server already crashed or has been shutdown.
-    #[snafu(display("Server does not exist or not running"))]
+    #[snafu(display("Server does not exist or is not running ({context})"))]
     ServerMissing,
 }
 


### PR DESCRIPTION
Previously, these error types had context, but did not display it. This meant enhanced logs didn't get stack traces even when they were being captured.