### PR TITLE
Add paths to the return value of lookup_by_type

### DIFF
--- a/ostd/src/orpc/oqueue/registry.rs
+++ b/ostd/src/orpc/oqueue/registry.rs
@@ -121,18 +121,21 @@ pub fn lookup_by_path_pattern<T: ?Sized + 'static>(pat: &PathPattern) -> Vec<Any
 }
 
 /// Get all OQueues of a given type.
-pub fn lookup_by_type<T: ?Sized + 'static>() -> Vec<AnyOQueueRef<T>> {
+pub fn lookup_by_type<T: ?Sized + 'static>() -> Vec<(Path, AnyOQueueRef<T>)> {
     let mut map = registry();
     let type_map = get_type_map::<T>(&mut map);
 
     type_map
         .map
-        .values()
-        .filter_map(|value| {
-            value
-                .downcast_ref::<WeakAnyOQueueRef<T>>()
-                .unwrap()
-                .upgrade()
+        .iter()
+        .filter_map(|(path, value)| {
+            Some((
+                path.clone(),
+                value
+                    .downcast_ref::<WeakAnyOQueueRef<T>>()
+                    .unwrap()
+                    .upgrade()?,
+            ))
         })
         .collect()
 }
@@ -209,6 +212,8 @@ mod test {
 
         let results = lookup_by_type::<usize>();
         assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, path!(x.y[1]));
+        assert_eq!(results[1].0, path!(z.w[2]));
     }
 
     #[ktest]


### PR DESCRIPTION
This adds the path of the OQueue to the list returned from `lookup_by_type`. This is NOT a complete PR. It should add paths to all lookup functions which return multiple OQueues. However there is a discussion to be had here.

*Should OQueues know there own path?* If yes, then the OQueues can be returned directly. This is the OO approach and works well if OQueues have a canonical path. If not, then the path needs to be returned here. This is the "data oriented" approach where values do not really represent specific things with identify. This simplifies having OQueues with multiple paths (which does make sense if servers can have multiple paths or names).

Thoughts?

