### PR TITLE
Add paths metadata and accessor to OQueues.

### DIFF
--- a/ostd/src/orpc/oqueue/implementation.rs
+++ b/ostd/src/orpc/oqueue/implementation.rs
@@ -37,6 +37,7 @@ use crate::{
             Cursor, InlineStrongObserver, OQueueError, ObservationQuery, ResourceUnavailableSnafu,
             single_thread_ring_buffer::RingBuffer,
         },
+        path::Path,
     },
     sync::{LocalIrqDisabled, SpinLock, WaitQueue, WakerKey},
 };
@@ -65,6 +66,7 @@ pub(crate) struct OQueueImplementation<T: ?Sized> {
     /// The size to use for the consumer and strong-observer ring-buffers.
     len: usize,
     supports_consume: bool,
+    path: Option<Path>,
     pub(super) put_wait_queue: WaitQueue,
     pub(super) read_wait_queue: WaitQueue,
 }
@@ -74,7 +76,9 @@ impl<T: ?Sized + 'static> OQueueImplementation<T> {
     ///
     /// * `len` is the ring buffer length used for consumers and strong-observers.
     /// * `supports_consume` specifies the attachment it allows later.
-    pub(crate) fn new(mut len: usize, supports_consume: bool) -> Self {
+    /// * `paths` are the paths associated with this OQueue; pass an empty `Vec` for anonymous
+    ///   queues.
+    pub(crate) fn new(mut len: usize, supports_consume: bool, path: Option<Path>) -> Self {
         if len < 2 {
             warn!(
                 "Creating an OQueue with length {len} is automatically increased to 2. Ring buffers smaller than 2 are not supported."
@@ -91,9 +95,15 @@ impl<T: ?Sized + 'static> OQueueImplementation<T> {
             }),
             len,
             supports_consume,
+            path,
             put_wait_queue: WaitQueue::new(),
             read_wait_queue: WaitQueue::new(),
         }
+    }
+
+    /// Return the path associated with this OQueue, or `None` for anonymous queues.
+    pub(super) fn path(&self) -> Option<&Path> {
+        self.path.as_ref()
     }
 
     /// Detach a consumer. This will free the consumer ring buffer if there are no consumers left.

--- a/ostd/src/orpc/oqueue/mod.rs
+++ b/ostd/src/orpc/oqueue/mod.rs
@@ -139,6 +139,9 @@ pub trait OQueueBase<T: ?Sized> {
     where
         U: Copy + Send + 'static;
 
+    /// Return the path of this OQueue, or `None` if it is anonymous.
+    fn path(&self) -> Option<&Path>;
+
     /// Erase the kind of OQueue. This will not allow additional operations to succeed. It
     /// simply makes the checks dynamic.
     fn as_any_oqueue(&self) -> AnyOQueueRef<T>;
@@ -196,6 +199,10 @@ macro_rules! impl_oqueue_base_forward {
             ) -> Result<InlineStrongObserver, OQueueError>
             {
                 self.$member.attach_inline_strong_observer(f)
+            }
+
+            fn path(&self) -> Option<&Path> {
+                self.$member.path()
             }
 
             fn as_any_oqueue(&self) -> AnyOQueueRef<T> {
@@ -286,7 +293,12 @@ impl<T: Send + 'static> ConsumableOQueueRef<T> {
     /// Create a new OQueue with the specified buffer length and support for produce by value and
     /// consumers.
     pub fn new(len: usize, path: Path) -> Self {
-        let ret = Self::new_anonymous(len);
+        let inner = Arc::new(implementation::OQueueImplementation::new(
+            len,
+            true,
+            Some(path.clone()),
+        ));
+        let ret = Self { inner };
         registry::register(&path, ret.as_any_oqueue());
         ret
     }
@@ -296,7 +308,7 @@ impl<T: Send + 'static> ConsumableOQueueRef<T> {
     /// observation such as for ephemeral queues.
     pub fn new_anonymous(len: usize) -> Self {
         Self {
-            inner: Arc::new(implementation::OQueueImplementation::new(len, true)),
+            inner: Arc::new(implementation::OQueueImplementation::new(len, true, None)),
         }
     }
 }
@@ -316,7 +328,13 @@ clone_without_t!(OQueueRef, : ?Sized + 'static);
 impl<T: ?Sized + Send + 'static> OQueueRef<T> {
     /// Create a new observation OQueue with the specified buffer length.
     pub fn new(len: usize, path: Path) -> Self {
-        let ret = Self::new_anonymous(len);
+        let ret = Self {
+            inner: Arc::new(implementation::OQueueImplementation::new(
+                len,
+                false,
+                Some(path.clone()),
+            )),
+        };
         registry::register(&path, ret.as_any_oqueue());
         ret
     }
@@ -325,7 +343,7 @@ impl<T: ?Sized + Send + 'static> OQueueRef<T> {
     /// when the OQueue should never be discovered for observation such as for ephemeral queues.
     pub fn new_anonymous(len: usize) -> Self {
         Self {
-            inner: Arc::new(implementation::OQueueImplementation::new(len, false)),
+            inner: Arc::new(implementation::OQueueImplementation::new(len, false, None)),
         }
     }
 }
@@ -1159,5 +1177,14 @@ mod test {
         generic_test::test_strong_observer_late_attach(ConsumableOQueueRef::<
             generic_test::TestMessage,
         >::new(4, Path::test()));
+    }
+
+    #[ktest]
+    fn oqueue_path() {
+        let named = ConsumableOQueueRef::<u32>::new(4, Path::test());
+        assert_eq!(named.path(), Some(&Path::test()));
+
+        let anon = ConsumableOQueueRef::<u32>::new_anonymous(4);
+        assert_eq!(anon.path(), None);
     }
 }


### PR DESCRIPTION
This adds path metadata to OQueues in a way that it can be accessed via the OQueueRef.