### PR TITLE
Add universal init_for_ktest

### DIFF
--- a/kernel/comps/systree/src/lib.rs
+++ b/kernel/comps/systree/src/lib.rs
@@ -49,11 +49,6 @@ fn init() -> core::result::Result<(), ComponentInitError> {
     Ok(())
 }
 
-#[cfg(ktest)]
-pub fn init_for_ktest() {
-    SINGLETON.call_once(|| Arc::new(SysTree::new()));
-}
-
 /// Returns a reference to the global SysTree instance. Panics if not initialized. (Asterinas specific)
 pub fn singleton() -> &'static Arc<SysTree> {
     SINGLETON.get().expect("SysTree not initialized")

--- a/kernel/src/fs/exfat/mod.rs
+++ b/kernel/src/fs/exfat/mod.rs
@@ -123,6 +123,7 @@ mod test {
 
     // Generate a simulated exfat file system
     fn load_exfat() -> Arc<ExfatFS> {
+        crate::init_for_ktest();
         let segment = new_vm_segment_from_image();
         let disk = ExfatMemoryDisk::new(segment);
         let mount_option = ExfatMountOptions::default();

--- a/kernel/src/fs/overlayfs/fs.rs
+++ b/kernel/src/fs/overlayfs/fs.rs
@@ -1076,7 +1076,7 @@ mod tests {
     use crate::fs::{path::MountNode, ramfs::RamFS};
 
     fn create_overlay_fs() -> Arc<dyn FileSystem> {
-        crate::time::clocks::init_for_ktest();
+        crate::init_for_ktest();
 
         let mode = InodeMode::all();
         let upper = {
@@ -1121,7 +1121,7 @@ mod tests {
 
     #[ktest]
     fn obscured_multi_layers() {
-        crate::time::clocks::init_for_ktest();
+        crate::init_for_ktest();
 
         let mode = InodeMode::all();
         let upper = {

--- a/kernel/src/fs/sysfs/test.rs
+++ b/kernel/src/fs/sysfs/test.rs
@@ -15,7 +15,7 @@ use aster_systree::{
     Error as SysTreeError, Result as SysTreeResult, SysAttrFlags, SysAttrSet, SysAttrSetBuilder,
     SysBranchNode, SysBranchNodeFields, SysNode, SysNodeId, SysNodeType, SysNormalNodeFields,
     SysObj, SysStr, SysSymlink, SysTree, impl_cast_methods_for_branch, impl_cast_methods_for_node,
-    impl_cast_methods_for_symlink, init_for_ktest, singleton as systree_singleton,
+    impl_cast_methods_for_symlink, singleton as systree_singleton,
 };
 use inherit_methods_macro::inherit_methods;
 use ostd::{
@@ -30,7 +30,6 @@ use crate::{
         sysfs::fs::SysFs,
         utils::{DirentVisitor, FileSystem, InodeMode, InodeType},
     },
-    time::clocks::init_for_ktest as time_init_for_ktest,
 };
 
 // --- Mock SysTree Components ---
@@ -264,8 +263,7 @@ impl SysSymlink for MockSymlinkNode {
 
 // Create a mock SysTree instance populated with mock nodes.
 fn create_mock_systree_instance() -> &'static Arc<SysTree> {
-    time_init_for_ktest();
-    init_for_ktest();
+    crate::init_for_ktest();
     // Create nodes
     let root = systree_singleton().root();
     let branch1 = MockBranchNode::new("branch1");

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -137,6 +137,23 @@ pub fn init() {
     process::init();
 }
 
+#[cfg(ktest)]
+/// Initialize kernel subsystems for ktests. This is not a complete initialization, but does load
+/// all components.
+///
+/// This is idempotent and should be called in *every* test that needs it. This avoids at least some
+/// test order dependence.
+///
+/// TODO(arthurp, https://github.com/ldos-project/asterinas/issues/221): Something less ad-hoc.
+pub fn init_for_ktest() {
+    pub static INITIALIZED: Once<()> = Once::new();
+    INITIALIZED.call_once(|| {
+        component::init_all(component::parse_metadata!()).unwrap();
+        crate::time::init();
+        crate::vm::vmar::init();
+    });
+}
+
 fn ap_init() {
     fn ap_idle_thread() {
         log::info!(

--- a/kernel/src/syscall/madvise.rs
+++ b/kernel/src/syscall/madvise.rs
@@ -204,10 +204,9 @@ mod test {
 
     #[ktest]
     fn huge_mappings_are_split() {
+        crate::init_for_ktest();
+
         set_huge_mapping_enabled(true);
-        component::init_all(component::parse_metadata!()).unwrap();
-        crate::time::init();
-        crate::vm::vmar::init();
         let vmar = Vmar::<Full>::new_root();
 
         let start = map_huge_page(&vmar);
@@ -219,13 +218,10 @@ mod test {
 
     #[ktest]
     fn huge_mappings_are_not_split() {
+        crate::init_for_ktest();
+
         set_huge_mapping_enabled(true);
         set_huge_mapping_preserve_on_dontneed(true);
-        // TODO(aneesh) - there needs to be an initialize phase that's run exactly ONCE for all
-        // test, otherwise init_all will fail.
-        // component::init_all(component::parse_metadata!()).unwrap();
-        // crate::time::init();
-        // crate::vm::vmar::init();
         let vmar = Vmar::<Full>::new_root();
 
         let start = map_huge_page(&vmar);

--- a/kernel/src/time/clocks/system_wide.rs
+++ b/kernel/src/time/clocks/system_wide.rs
@@ -300,24 +300,3 @@ pub(super) fn init() {
     init_jiffies_clock_manager();
     init_coarse_clock();
 }
-
-#[cfg(ktest)]
-/// Init `CLOCK_REALTIME_MANAGER` for process-related ktests.
-///
-/// TODO: `ktest` may require a feature that allows the registration of initialization functions
-/// to avoid functions like this one.
-pub fn init_for_ktest() {
-    // If `spin::Once` has initialized, this closure will not be executed.
-    for cpu in ostd::cpu::all_cpus() {
-        CLOCK_REALTIME_MANAGER.get_on_cpu(cpu).call_once(|| {
-            let clock = RealTimeClock { _private: () };
-            TimerManager::new(Arc::new(clock))
-        });
-    }
-    CLOCK_REALTIME_COARSE_INSTANCE.call_once(|| Arc::new(RealTimeCoarseClock { _private: () }));
-    RealTimeCoarseClock::current_ref().call_once(|| SpinLock::new(Duration::from_secs(0)));
-    JIFFIES_TIMER_MANAGER.call_once(|| {
-        let clock = JiffiesClock { _private: () };
-        TimerManager::new(Arc::new(clock))
-    });
-}


### PR DESCRIPTION
This function replaces ad-hoc initialization performed for some ktests within the kernel/ crate. This is not an ideal solution. See https://github.com/ldos-project/asterinas/issues/221.