### PR TITLE
Expose call_in_context to user code and remove automatic wrapping.

### DIFF
--- a/kernel/comps/mariposa_data_capture/src/data_capture_file.rs
+++ b/kernel/comps/mariposa_data_capture/src/data_capture_file.rs
@@ -230,7 +230,8 @@ impl DataCaptureFileBuilder {
         // generally do, but this build function is required and can't be on a server (due to the
         // need to take a type parameter) and it's body should run in the context of the manager
         // server.
-        Server::orpc_server_base(self.server.as_ref())
+        self.server
+            .orpc_server_base()
             .call_in_context(move || -> Result<Arc<DataCaptureFileServer<T>>, RPCError> {
                 let command_oqueue =
                     ConsumableOQueueRef::new(8, self.path.append(&path!(commands)));

--- a/kernel/comps/mariposa_data_capture/src/legacy/data_capture_file.rs
+++ b/kernel/comps/mariposa_data_capture/src/legacy/data_capture_file.rs
@@ -197,7 +197,8 @@ impl DataCaptureFileBuilder {
     where
         T: Copy + Send + Serialize + 'static,
     {
-        Server::orpc_server_base(self.server.as_ref())
+        self.server
+            .orpc_server_base()
             .call_in_context(move || -> Result<Arc<DataCaptureFileServer<T>>, RPCError> {
                 let command_queue = LockingQueue::new(8);
                 let server = new_server!(|_| DataCaptureFileServer {

--- a/ostd/src/orpc/framework/mod.rs
+++ b/ostd/src/orpc/framework/mod.rs
@@ -49,15 +49,13 @@ use crate::{
 
 /// The primary trait for all server. This provides access to information and capabilities common to all servers.
 pub trait Server: Any + Sync + Send + 'static {
-    /// **INTERNAL** User code should never call this directly, however it cannot be private because generated code must
-    /// use it.
-    ///
-    /// Get a reference to the struct implementing all the fundamental server operations. This is effectively the base
-    /// class pointer of this server.
-    #[doc(hidden)]
+    /// Get a reference to the struct exposing all the fundamental server operations. This is
+    /// effectively the base class pointer of this server.
     fn orpc_server_base(&self) -> &ServerBase;
 }
 
+/// The next server ID to assign. This starts at 1, to allow the ID to be stored in
+/// [`NonZeroUsize`].
 static NEXT_SERVER_ID: AtomicUsize = AtomicUsize::new(1);
 
 /// The information and state included in every server. The name comes form it being the "base class" state for all
@@ -97,7 +95,7 @@ impl ServerBase {
     ///
     /// Returns true if the server was aborted.
     #[doc(hidden)]
-    pub fn is_aborted(&self) -> bool {
+    fn is_aborted(&self) -> bool {
         self.aborted.load(Ordering::Relaxed)
     }
 
@@ -106,7 +104,7 @@ impl ServerBase {
     ///
     /// Abort a server.
     #[doc(hidden)]
-    pub fn abort(&self, _payload: &impl Display) {
+    fn abort(&self, _payload: &impl Display) {
         self.aborted.store(true, Ordering::SeqCst);
         // Wake up all the threads in the server. This assumes that all threads have an abort point
         let server_threads = self.server_threads.lock();
@@ -116,7 +114,7 @@ impl ServerBase {
     }
 
     /// Attack a task to this server.
-    pub fn attach_task(&self) {
+    fn attach_task(&self) {
         let mut server_threads = self.server_threads.lock();
         server_threads.push(Task::current().unwrap().cloned());
     }
@@ -124,7 +122,7 @@ impl ServerBase {
     /// Check if the server has aborted and panic if it has. This should be called periodically from all server threads
     /// to guarantee that servers will crash fully if any part of them crashes. (This is analogous to a cancelation
     /// point in pthreads.)
-    pub fn abort_point(&self) {
+    fn abort_point(&self) {
         if self.is_aborted() {
             panic!("Server aborted in another thread");
         }
@@ -135,12 +133,14 @@ impl ServerBase {
         self.weak_this.upgrade()
     }
 
-    /// **INTERNAL** User code should never call this directly, however it cannot be private because macro generated
-    /// code must use it.
+    /// Call a function in the context of this server.
     ///
-    /// Call a function in the context of this server. This is used to implement method calls on
-    /// servers and similar things.
-    #[doc(hidden)]
+    /// This is used to implement method calls on servers and similar things. It should be used in
+    /// user code, to transition into server code from within a callback without having to create a
+    /// new method.
+    ///
+    /// This is public, but should be considered an escape hatch and only used when other framework
+    /// tools do not provide what is required.
     pub fn call_in_context<T, E>(&self, f: impl FnOnce() -> Result<T, E>) -> Result<T, E>
     where
         RPCError: Into<E>,

--- a/ostd/src/orpc/oqueue/implementation.rs
+++ b/ostd/src/orpc/oqueue/implementation.rs
@@ -31,8 +31,6 @@ use static_assertions::assert_obj_safe;
 
 use crate::{
     orpc::{
-        errors::RPCError,
-        framework::CurrentServer,
         oqueue::{
             Cursor, InlineStrongObserver, OQueueError, ObservationQuery, ResourceUnavailableSnafu,
             single_thread_ring_buffer::RingBuffer,
@@ -173,7 +171,7 @@ impl<T: ?Sized + 'static> OQueueImplementation<T> {
         f: impl Fn(&T) + Send + 'static,
     ) -> Result<InlineStrongObserver, super::OQueueError> {
         let mut inner = self.inner.lock();
-        let key = inner.inline_strong_observers.insert(wrap_closure_ref(f));
+        let key = inner.inline_strong_observers.insert(Box::new(f));
         Ok(super::InlineStrongObserver {
             oqueue: self.clone(),
             inline_observer_id: key,
@@ -219,13 +217,13 @@ impl<T: ?Sized + 'static> OQueueImplementation<T> {
         }
 
         // Register the actual handler
-        let key = inner
-            .inline_strong_observers
-            .insert(wrap_closure_ref(move |v| {
+        let key = inner.inline_strong_observers.insert(Box::new(
+            (move |v| {
                 if let Some(v) = query.call(v) {
                     f(&v)
                 }
-            }));
+            }),
+        ));
 
         Ok(key)
     }
@@ -253,26 +251,6 @@ impl<T: ?Sized + 'static> OQueueImplementation<T> {
         super::AnyOQueueRef {
             inner: self.clone(),
         }
-    }
-}
-
-/// Wrap a closure to run in the context of the current server if there is one.
-fn wrap_closure_ref<T: ?Sized + 'static>(
-    f: impl Fn(&T) + Send + 'static,
-) -> Box<dyn Fn(&T) + Send> {
-    // TODO(arthurp): Capturing the current server into the closure is really part of ORPC and so
-    // shouldn't be here in the OQueue implementation. It also forces this overhead on every
-    // closure.
-    if let Some(s) = CurrentServer::current_cloned() {
-        let f: Box<dyn Fn(&T) + Send + 'static> = Box::new(move |v| {
-            let _ = s.orpc_server_base().call_in_context::<_, RPCError>(|| {
-                f(v);
-                Ok(())
-            });
-        });
-        f
-    } else {
-        Box::new(f)
     }
 }
 

--- a/ostd/src/orpc/oqueue/mod.rs
+++ b/ostd/src/orpc/oqueue/mod.rs
@@ -119,7 +119,8 @@ pub trait OQueueBase<T: ?Sized> {
         U: Copy + Send + 'static;
 
     /// Attach a strong observer to the OQueue by calling a strong observer function with each
-    /// value.
+    /// value. This function does not run in the context of any server. If the function should, it
+    /// should use [`crate::orpc::framework::ServerBase::call_in_context`].
     ///
     /// Note: This is different from [`StrongObserver::strong_observe_inline`] because this
     /// observes the entire message without requiring a filter.
@@ -449,7 +450,9 @@ impl<T: Send + 'static> Consumer<T> {
         self.oqueue.try_consume()
     }
 
-    /// Register a function to be called by the OQueue to observe each message.
+    /// Register a function to be called by the OQueue to observe each message. This function does
+    /// not run in the context of any server. If the function should, it should use
+    /// [`crate::orpc::framework::ServerBase::call_in_context`].
     ///
     /// This consumes `self`, because the messages will now be consumed via a different mechanism.
     /// This will return an error if switching to inline is impossible or meaningless, for example
@@ -565,7 +568,9 @@ impl<U: Copy + Send + 'static> StrongObserver<U> {
         }
     }
 
-    /// Register a function to be called by the OQueue to observe each message.
+    /// Register a function to be called by the OQueue to observe each message. This function does
+    /// not run in the context of any server. If the function should, it should use
+    /// [`crate::orpc::framework::ServerBase::call_in_context`].
     ///
     /// This consumes `self`, because the messages will now be observed via a different mechanism.
     /// This will return an error if switching to inline is impossible.


### PR DESCRIPTION
This exposes the previously internal `orpc_server_base` so that user code can call `call_in_context`. This is needed because inline strong observers and consumers are no longer automatically wrapped to run in the server that added them. The wrapping was removed because it was a forced overhead and it forced the OQueue implementation to be aware of ORPC.

Higher-level interfaces may be added to do this, potentially `OrpcClosure::new(|| ...)`. However, the exact form is TBD and it will probably integrate with the work on sync/async_now/async_later which is coming down the pipe. So I will leave the high-level API as future work.