### PR TITLE
Fix OQueue Panics by Preventing the Cursor Underflow.

### DIFF
--- a/ostd/src/orpc/oqueue/mod.rs
+++ b/ostd/src/orpc/oqueue/mod.rs
@@ -618,6 +618,9 @@ impl Sub<usize> for Cursor {
     type Output = Cursor;
 
     fn sub(self, rhs: usize) -> Self::Output {
+        /// Using wrapping_sub in the case of Cursor underflow. 
+        /// Assumes the Cursor would never reaches the larger end of usize
+        /// More Details see [PR #228](https://github.com/ldos-project/asterinas/pull/228)
         Cursor(self.0.wrapping_sub(rhs))
     }
 }

--- a/ostd/src/orpc/oqueue/mod.rs
+++ b/ostd/src/orpc/oqueue/mod.rs
@@ -616,11 +616,17 @@ impl Add<usize> for Cursor {
 
 impl Sub<usize> for Cursor {
     type Output = Cursor;
-
+    
+    /// Subtracts `rhs` from this cursor using wrapping arithmetic.
+    ///
+    /// This intentionally uses `wrapping_sub` so that cursor underflow wraps
+    /// instead of panicking or saturating. This is safe under the assumption that
+    /// `Cursor` values never reach the larger end of `usize`, which takes impractically
+    /// amount of time. 
+    ///
+    /// See PR #228 for the design rationale:
+    /// <https://github.com/ldos-project/asterinas/pull/228>
     fn sub(self, rhs: usize) -> Self::Output {
-        /// Using wrapping_sub in the case of Cursor underflow. 
-        /// Assumes the Cursor would never reaches the larger end of usize
-        /// More Details see [PR #228](https://github.com/ldos-project/asterinas/pull/228)
         Cursor(self.0.wrapping_sub(rhs))
     }
 }

--- a/ostd/src/orpc/oqueue/mod.rs
+++ b/ostd/src/orpc/oqueue/mod.rs
@@ -616,13 +616,13 @@ impl Add<usize> for Cursor {
 
 impl Sub<usize> for Cursor {
     type Output = Cursor;
-    
+
     /// Subtracts `rhs` from this cursor using wrapping arithmetic.
     ///
     /// This intentionally uses `wrapping_sub` so that cursor underflow wraps
     /// instead of panicking or saturating. This is safe under the assumption that
     /// `Cursor` values never reach the larger end of `usize`, which takes impractically
-    /// amount of time. 
+    /// amount of time.
     ///
     /// See PR #228 for the design rationale:
     /// <https://github.com/ldos-project/asterinas/pull/228>

--- a/ostd/src/orpc/oqueue/mod.rs
+++ b/ostd/src/orpc/oqueue/mod.rs
@@ -618,7 +618,7 @@ impl Sub<usize> for Cursor {
     type Output = Cursor;
 
     fn sub(self, rhs: usize) -> Self::Output {
-        Cursor(self.0 - rhs)
+        Cursor(self.0.wrapping_sub(rhs))
     }
 }
 


### PR DESCRIPTION
The legacy OQueue uses `saturation_sub` as the solution to prevent underflowing OQueue reads, i.e., reads at the very early stage of the OQueue at index `i-h` where $$h>i$$. In the new OQueue implementation, such underflow panics the kernel since there are no prevention mechanisms and the cursor value is a `usize`. 
 
Thus, the correct solution is to use `wrapping_sub`, because the wrapping around of `usize` at the lower end results in numbers at the larger end of an unsigned 64-bit integer, which is not practically achievable by the normal use of an OQueue and thus easy to identify. At the same time, this prevents always reading the same value, which using `saturating_sub` will result in. 