### PR TITLE
Add OQueues to track accept/close syscalls

### DIFF
--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
+#[cfg(not(baseline_asterinas))]
 use ostd::orpc::legacy_oqueue::OQueue;
 
 use super::SyscallReturn;

--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -22,12 +22,7 @@ pub fn sys_accept(
     debug!("sockfd = {sockfd}, sockaddr_ptr = 0x{sockaddr_ptr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
     let fd = do_accept(sockfd, sockaddr_ptr, addrlen_ptr, Flags::empty(), ctx)?;
-    #[cfg(not(baseline_asterinas))]
-    super::get_socket_oqueue().produce(super::SocketOQueueMessage {
-        fd: fd,
-        is_close: 0,
-        timestamp: MonotonicRawClock::get().read_time().as_nanos(),
-    })?;
+
     Ok(SyscallReturn::Return(fd as _))
 }
 
@@ -46,12 +41,6 @@ pub fn sys_accept4(
     );
 
     let fd = do_accept(sockfd, sockaddr_ptr, addrlen_ptr, flags, ctx)?;
-    #[cfg(not(baseline_asterinas))]
-    super::get_socket_oqueue().produce(super::SocketOQueueMessage {
-        fd: fd,
-        is_close: 0,
-        timestamp: MonotonicRawClock::get().read_time().as_nanos(),
-    })?;
 
     Ok(SyscallReturn::Return(fd as _))
 }
@@ -93,6 +82,13 @@ fn do_accept(
         let mut file_table_locked = file_table.unwrap().write();
         file_table_locked.insert(connected_socket, fd_flags)
     };
+
+    #[cfg(not(baseline_asterinas))]
+    super::get_socket_oqueue().produce(super::SocketOQueueMessage {
+        fd,
+        is_close: 0,
+        timestamp: MonotonicRawClock::get().read_time(),
+    })?;
 
     Ok(fd)
 }

--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -85,7 +85,7 @@ fn do_accept(
     };
 
     #[cfg(not(baseline_asterinas))]
-    super::get_socket_oqueue().produce(super::SocketOQueueMessage {
+    super::oqueue::get_socket_oqueue().produce(super::oqueue::SocketOQueueMessage {
         fd,
         is_close: 0,
         timestamp: MonotonicRawClock::get().read_time(),

--- a/kernel/src/syscall/accept.rs
+++ b/kernel/src/syscall/accept.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
+use ostd::orpc::legacy_oqueue::OQueue;
 
 use super::SyscallReturn;
+#[cfg(not(baseline_asterinas))]
+use crate::time::clocks::MonotonicRawClock;
 use crate::{
     fs::{
         file_table::{FdFlags, FileDesc, get_file_fast},
@@ -19,6 +22,12 @@ pub fn sys_accept(
     debug!("sockfd = {sockfd}, sockaddr_ptr = 0x{sockaddr_ptr:x}, addrlen_ptr = 0x{addrlen_ptr:x}");
 
     let fd = do_accept(sockfd, sockaddr_ptr, addrlen_ptr, Flags::empty(), ctx)?;
+    #[cfg(not(baseline_asterinas))]
+    super::get_socket_oqueue().produce(super::SocketOQueueMessage {
+        fd: fd,
+        is_close: 0,
+        timestamp: MonotonicRawClock::get().read_time().as_nanos(),
+    })?;
     Ok(SyscallReturn::Return(fd as _))
 }
 
@@ -37,6 +46,13 @@ pub fn sys_accept4(
     );
 
     let fd = do_accept(sockfd, sockaddr_ptr, addrlen_ptr, flags, ctx)?;
+    #[cfg(not(baseline_asterinas))]
+    super::get_socket_oqueue().produce(super::SocketOQueueMessage {
+        fd: fd,
+        is_close: 0,
+        timestamp: MonotonicRawClock::get().read_time().as_nanos(),
+    })?;
+
     Ok(SyscallReturn::Return(fd as _))
 }
 

--- a/kernel/src/syscall/close.rs
+++ b/kernel/src/syscall/close.rs
@@ -32,7 +32,7 @@ pub fn sys_close(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
 
     if file.as_socket_or_err().is_ok() {
         #[cfg(not(baseline_asterinas))]
-        super::get_socket_oqueue().produce(super::SocketOQueueMessage {
+        super::oqueue::get_socket_oqueue().produce(super::oqueue::SocketOQueueMessage {
             fd,
             is_close: 1,
             timestamp: MonotonicRawClock::get().read_time(),

--- a/kernel/src/syscall/close.rs
+++ b/kernel/src/syscall/close.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use bitflags::bitflags;
-use ostd::{orpc::legacy_oqueue::OQueue, sync::RwArc};
+#[cfg(not(baseline_asterinas))]
+use ostd::orpc::legacy_oqueue::OQueue;
+use ostd::sync::RwArc;
 
 use super::SyscallReturn;
 #[cfg(not(baseline_asterinas))]

--- a/kernel/src/syscall/close.rs
+++ b/kernel/src/syscall/close.rs
@@ -31,9 +31,9 @@ pub fn sys_close(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
     if file.as_socket_or_err().is_ok() {
         #[cfg(not(baseline_asterinas))]
         super::get_socket_oqueue().produce(super::SocketOQueueMessage {
-            fd: fd,
+            fd,
             is_close: 1,
-            timestamp: MonotonicRawClock::get().read_time().as_nanos(),
+            timestamp: MonotonicRawClock::get().read_time(),
         })?;
     }
 

--- a/kernel/src/syscall/close.rs
+++ b/kernel/src/syscall/close.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use bitflags::bitflags;
-use ostd::sync::RwArc;
+use ostd::{orpc::legacy_oqueue::OQueue, sync::RwArc};
 
 use super::SyscallReturn;
+#[cfg(not(baseline_asterinas))]
+use crate::time::clocks::MonotonicRawClock;
 use crate::{
     fs::file_table::{FdFlags, FileDesc},
     prelude::*,
@@ -25,6 +27,15 @@ pub fn sys_close(fd: FileDesc, ctx: &Context) -> Result<SyscallReturn> {
         let _ = file_table_locked.get_file(fd)?;
         file_table_locked.close_file(fd).unwrap()
     };
+
+    if file.as_socket_or_err().is_ok() {
+        #[cfg(not(baseline_asterinas))]
+        super::get_socket_oqueue().produce(super::SocketOQueueMessage {
+            fd: fd,
+            is_close: 1,
+            timestamp: MonotonicRawClock::get().read_time().as_nanos(),
+        })?;
+    }
 
     // Cleanup work needs to be done in the `Drop` impl.
     //

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -396,23 +396,26 @@ macro_rules! log_syscall_entry {
     };
 }
 
-#[derive(Clone, Copy, Serialize)]
-pub struct SocketOQueueMessage {
-    fd: i32,
-    is_close: u8,
-    timestamp: Duration,
-}
+#[cfg(not(baseline_asterinas))]
+pub mod oqueue {
+    #[derive(Clone, Copy, Serialize)]
+    pub struct SocketOQueueMessage {
+        pub fd: i32,
+        pub is_close: u8,
+        pub timestamp: Duration,
+    }
 
-static SOCKET_OQUEUE: Once<Arc<MPMCOQueue<SocketOQueueMessage>>> = Once::new();
+    static SOCKET_OQUEUE: Once<Arc<MPMCOQueue<SocketOQueueMessage>>> = Once::new();
 
-pub fn get_socket_oqueue() -> Arc<MPMCOQueue<SocketOQueueMessage>> {
-    SOCKET_OQUEUE.wait().clone()
+    pub fn get_socket_oqueue() -> Arc<MPMCOQueue<SocketOQueueMessage>> {
+        SOCKET_OQUEUE.wait().clone()
+    }
 }
 
 pub(super) fn init() {
     uname::init();
     #[cfg(not(baseline_asterinas))]
     {
-        SOCKET_OQUEUE.call_once(|| MPMCOQueue::new(1024, 2));
+        ::oqueue::SOCKET_OQUEUE.call_once(|| MPMCOQueue::new(1024, 2));
     }
 }

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2,15 +2,11 @@
 
 //! System call handlers.
 
+use alloc::sync::Arc;
 use core::time::Duration;
 
-use alloc::sync::Arc;
-
 pub use clock_gettime::ClockId;
-use ostd::{
-    cpu::context::UserContext,
-    orpc::legacy_oqueue::ringbuffer::MPMCOQueue,
-};
+use ostd::{cpu::context::UserContext, orpc::legacy_oqueue::ringbuffer::MPMCOQueue};
 use serde::Serialize;
 use spin::Once;
 pub use timer_create::create_timer;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2,8 +2,15 @@
 
 //! System call handlers.
 
+use alloc::sync::Arc;
+
 pub use clock_gettime::ClockId;
-use ostd::cpu::context::UserContext;
+use ostd::{
+    cpu::context::UserContext,
+    orpc::legacy_oqueue::{OQueue, ringbuffer::MPMCOQueue},
+};
+use serde::Serialize;
+use spin::Once;
 pub use timer_create::create_timer;
 
 use crate::{context::Context, cpu::LinuxAbi, prelude::*};
@@ -389,6 +396,23 @@ macro_rules! log_syscall_entry {
     };
 }
 
+#[derive(Clone, Copy, Serialize)]
+pub struct SocketOQueueMessage {
+    fd: i32,
+    is_close: u8,
+    timestamp: u128,
+}
+
+static SOCKET_OQUEUE: Once<Arc<MPMCOQueue<SocketOQueueMessage>>> = Once::new();
+
+pub fn get_socket_oqueue() -> Arc<MPMCOQueue<SocketOQueueMessage>> {
+    SOCKET_OQUEUE.wait().clone()
+}
+
 pub(super) fn init() {
     uname::init();
+    #[cfg(not(baseline_asterinas))]
+    {
+        SOCKET_OQUEUE.call_once(|| MPMCOQueue::new(1024, 2));
+    }
 }

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2,15 +2,8 @@
 
 //! System call handlers.
 
-use alloc::sync::Arc;
-use core::time::Duration;
-
 pub use clock_gettime::ClockId;
 use ostd::cpu::context::UserContext;
-#[cfg(not(baseline_asterinas))]
-use ostd::orpc::legacy_oqueue::ringbuffer::MPMCOQueue;
-use serde::Serialize;
-use spin::Once;
 pub use timer_create::create_timer;
 
 use crate::{context::Context, cpu::LinuxAbi, prelude::*};
@@ -398,6 +391,13 @@ macro_rules! log_syscall_entry {
 
 #[cfg(not(baseline_asterinas))]
 pub mod oqueue {
+    use alloc::sync::Arc;
+    use core::time::Duration;
+
+    use ostd::orpc::legacy_oqueue::ringbuffer::MPMCOQueue;
+    use serde::Serialize;
+    use spin::Once;
+
     #[derive(Clone, Copy, Serialize)]
     pub struct SocketOQueueMessage {
         pub fd: i32,

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -407,6 +407,10 @@ pub mod oqueue {
 
     static SOCKET_OQUEUE: Once<Arc<MPMCOQueue<SocketOQueueMessage>>> = Once::new();
 
+    pub fn init() {
+        SOCKET_OQUEUE.call_once(|| MPMCOQueue::new(1024, 2));
+    }
+
     pub fn get_socket_oqueue() -> Arc<MPMCOQueue<SocketOQueueMessage>> {
         SOCKET_OQUEUE.wait().clone()
     }
@@ -415,7 +419,5 @@ pub mod oqueue {
 pub(super) fn init() {
     uname::init();
     #[cfg(not(baseline_asterinas))]
-    {
-        ::oqueue::SOCKET_OQUEUE.call_once(|| MPMCOQueue::new(1024, 2));
-    }
+    oqueue::init();
 }

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -6,7 +6,9 @@ use alloc::sync::Arc;
 use core::time::Duration;
 
 pub use clock_gettime::ClockId;
-use ostd::{cpu::context::UserContext, orpc::legacy_oqueue::ringbuffer::MPMCOQueue};
+use ostd::cpu::context::UserContext;
+#[cfg(not(baseline_asterinas))]
+use ostd::orpc::legacy_oqueue::ringbuffer::MPMCOQueue;
 use serde::Serialize;
 use spin::Once;
 pub use timer_create::create_timer;

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -2,12 +2,14 @@
 
 //! System call handlers.
 
+use core::time::Duration;
+
 use alloc::sync::Arc;
 
 pub use clock_gettime::ClockId;
 use ostd::{
     cpu::context::UserContext,
-    orpc::legacy_oqueue::{OQueue, ringbuffer::MPMCOQueue},
+    orpc::legacy_oqueue::ringbuffer::MPMCOQueue,
 };
 use serde::Serialize;
 use spin::Once;
@@ -400,7 +402,7 @@ macro_rules! log_syscall_entry {
 pub struct SocketOQueueMessage {
     fd: i32,
     is_close: u8,
-    timestamp: u128,
+    timestamp: Duration,
 }
 
 static SOCKET_OQUEUE: Once<Arc<MPMCOQueue<SocketOQueueMessage>>> = Once::new();


### PR DESCRIPTION
These OQueues are useful for tracking events during other benchmarks and can be consumed by policies and policy training (e.g. during YCSB runs for tracking memory usage)