### PR TITLE
Make jdk better at finding versions

### DIFF
--- a/test/benchmark/common/prepare_host.sh
+++ b/test/benchmark/common/prepare_host.sh
@@ -48,10 +48,24 @@ prepare_fs() {
 
 JDK_URL="https://download.oracle.com/java/25/latest/jdk-25_linux-x64_bin.tar.gz"
 MVN_URL="https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz"
-export MVN_DIR=$(realpath ".cache/apache-maven-3.9.12")
-export YCSB_PATH=$(realpath ".cache/ycsb")
-export JDK_PATH=$(realpath ".cache/jdk-25.0.2")
+export CACHE_DIR=$(realpath -m ".cache")
+export MVN_DIR=$(realpath -m "${CACHE_DIR}/apache-maven-3.9.12")
+export YCSB_PATH=$(realpath -m "${CACHE_DIR}/ycsb")
+resolve_jdk_path() {
+  shopt -s nullglob
+  local jdk_latest=(ls -1 ${CACHE_DIR}"/jdk-* |sort -V |tail -n 1)
+  shopt -u nullglob
+
+  if [ $jdk_latest -eq 0 ]; then
+    return 1
+  fi
+
+  realpath "$jdk_latest"
+}
+
+export JDK_PATH=$(resolve_jdk_path || true)
 export JAVA_HOME=$JDK_PATH
+
 
 prepare_ycsb() {
   mkdir -p .cache
@@ -60,6 +74,8 @@ prepare_ycsb() {
     if [ ! -d "$JDK_PATH" ]; then
       wget "$JDK_URL" -O jdk.tar.gz
       tar -xvf ./jdk.tar.gz
+      export JDK_PATH=$(resolve_jdk_path)
+      export JAVA_HOME=$JDK_PATH
     fi
 
     if [ ! -d "$MVN_DIR" ]; then
@@ -72,6 +88,10 @@ prepare_ycsb() {
       git clone https://github.com/tewaro/YCSB.git -b tewaro/quickfix-coreworkload-deletes-master --depth=1 $YCSB_PATH
 
       # Build
+      if [ ! -x "$JAVA_HOME/bin/java" ]; then
+        echo "Invalid JAVA_HOME: $JAVA_HOME" >&2
+        exit 1
+      fi
       pushd $YCSB_PATH
       $MVN_DIR/bin/mvn -pl site.ycsb:redis-binding -am clean package
       $MVN_DIR/bin/mvn -pl site.ycsb:memcached-binding -am clean package


### PR DESCRIPTION
jdk-25 has gone up a minor version number, just fix prepare_ycsb to adopt whatever the minor version is by doing with little bit of shell scripting.