### PR TITLE
fix: pin unwinding version to 0.2.8

### DIFF
--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -37,7 +37,7 @@ spin = "0.9.4"
 slotmap = { version = "1.0", default-features = false }
 smallvec = { version = "1.15.1", features = ["union"] }
 snafu = { workspace = true }
-unwinding = { version = "0.2.8", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
+unwinding = { version = "=0.2.8", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
 volatile = "0.6.1"
 bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 crossbeam-utils = { version = "0.8.21", default-features = false }


### PR DESCRIPTION
Version 0.2.9 of unwinding breaks the build with:

```
error[E0308]: mismatched types
  --> /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/unwinding-0.2.9/src/panicking.rs:42:19
   |
42 |         return if core::intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<E>) {
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `bool`, found `i32`
```

We pin it to 0.2.8 until we do the big merge and can address this issue.