### PR TITLE
Reconnect RAID Smoke Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ ENABLE_REGRESSION_TEST := true
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="INTEL_TDX=$(INTEL_TDX)"
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/run_regression_test.sh"
 else ifeq ($(AUTO_TEST), raid)
+ENABLE_REGRESSION_TEST := true
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/raid1.sh"
 else ifeq ($(AUTO_TEST), boot)
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/boot_hello.sh"

--- a/test/apps/raid1/Makefile
+++ b/test/apps/raid1/Makefile
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: MPL-2.0
-
-include ../test_common.mk
-
-EXTRA_C_FLAGS := -static

--- a/test/initramfs/nix/regression/default.nix
+++ b/test/initramfs/nix/regression/default.nix
@@ -10,7 +10,7 @@ let
   commonBuild = dir: callPackage ./common.nix (commonArgs // { inherit dir; });
 
   subDirs =
-    [ "device" "fs" "hello_world" "io" "ipc" "memory" "process" "security" ];
+    [ "device" "fs" "hello_world" "io" "ipc" "memory" "process" "security" "raid1"];
 
   tdxAttest = callPackage ./tdx-attest.nix { };
 

--- a/test/initramfs/nix/regression/default.nix
+++ b/test/initramfs/nix/regression/default.nix
@@ -9,8 +9,17 @@ let
   commonArgs = { inherit testPlatform; };
   commonBuild = dir: callPackage ./common.nix (commonArgs // { inherit dir; });
 
-  subDirs =
-    [ "device" "fs" "hello_world" "io" "ipc" "memory" "process" "security" "raid1"];
+  subDirs = [
+    "device"
+    "fs"
+    "hello_world"
+    "io"
+    "ipc"
+    "memory"
+    "process"
+    "security"
+    "raid1"
+  ];
 
   tdxAttest = callPackage ./tdx-attest.nix { };
 

--- a/test/initramfs/src/regression/Makefile
+++ b/test/initramfs/src/regression/Makefile
@@ -22,6 +22,7 @@ SUBDIRS := \
 	process \
 	scripts \
 	security \
+	raid1 \
 
 ifeq ($(HOST_PLATFORM), x86_64-linux)
 SUBDIRS += intel_tdx

--- a/test/initramfs/src/regression/raid1/Makefile
+++ b/test/initramfs/src/regression/raid1/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../common/Makefile

--- a/test/initramfs/src/regression/raid1/raid_smoke_test.c
+++ b/test/initramfs/src/regression/raid1/raid_smoke_test.c
@@ -20,8 +20,10 @@ int main()
 	int fd;
 	ssize_t n;
 	unsigned char *pattern, *read_back;
-	if (posix_memalign((void **)&pattern, 4096, RAID1_TEST_BLOCK_SIZE) != 0 ||
-	    posix_memalign((void **)&read_back, 4096, RAID1_TEST_BLOCK_SIZE) != 0) {
+	if (posix_memalign((void **)&pattern, 4096, RAID1_TEST_BLOCK_SIZE) !=
+		    0 ||
+	    posix_memalign((void **)&read_back, 4096, RAID1_TEST_BLOCK_SIZE) !=
+		    0) {
 		fprintf(stderr, "[raid-test] posix_memalign failed: %s\n",
 			strerror(errno));
 		return -1;

--- a/test/initramfs/src/regression/raid1/raid_smoke_test.c
+++ b/test/initramfs/src/regression/raid1/raid_smoke_test.c
@@ -20,8 +20,12 @@ int main()
 	int fd;
 	ssize_t n;
 	unsigned char *pattern, *read_back;
-	posix_memalign((void **)&pattern, 4096, RAID1_TEST_BLOCK_SIZE);
-	posix_memalign((void **)&read_back, 4096, RAID1_TEST_BLOCK_SIZE);
+	if (posix_memalign((void **)&pattern, 4096, RAID1_TEST_BLOCK_SIZE) != 0 ||
+	    posix_memalign((void **)&read_back, 4096, RAID1_TEST_BLOCK_SIZE) != 0) {
+		fprintf(stderr, "[raid-test] posix_memalign failed: %s\n",
+			strerror(errno));
+		return -1;
+	}
 	int i, ret = 0;
 
 	// Fill pattern buffer with known values


### PR DESCRIPTION
After the big upstream merge #236 the RAID smoke test is disconnected from the tree. This PR puts the test in the correct location and adds the test back as one of the regression tests. 