### PR TITLE
Add dropbear and a launcher script to the "run_kernel" environment

### DIFF
--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -160,6 +160,7 @@ initramfs_pkgs:
 		-A initramfs-image
 
 $(AUTHORIZED_KEYS_FILE):
+	@mkdir -p $(BUILD_DIR)
 	cat ${HOME}/.ssh/*.pub > $@
 
 $(EXT2_IMAGE):

--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -32,6 +32,7 @@ EXFAT_IMAGE := $(BUILD_DIR)/exfat.img
 CAPTURE_IMAGE := $(BUILD_DIR)/capture.img
 CAPTURE_LEGACY_IMAGE := $(BUILD_DIR)/capture_legacy.img
 CAPTURE_IMAGE_SIZE := 4G
+AUTHORIZED_KEYS_FILE := $(BUILD_DIR)/authorized_keys
 
 # Include benchmark, if BENCHMARK is set.
 ifeq ($(BENCHMARK), none)
@@ -71,11 +72,12 @@ $(INITRAMFS_IMAGE): $(INITRAMFS)
 		--argstr dnsServer ${DNS_SERVER} \
 		--arg initramfsCompressed $(INITRAMFS_COMPRESSED) \
 		--arg smp $(SMP) \
+		--arg-from-file authorized_keys $(AUTHORIZED_KEYS_FILE) \
 		--out-link $@ \
 		nix -A initramfs-image
 
 .PHONY: $(INITRAMFS)
-$(INITRAMFS):
+$(INITRAMFS): $(AUTHORIZED_KEYS_FILE)
 	@nix-build \
 		--tarball-ttl $(NIXPKGS_CACHE_TTL) \
 		--argstr target $(OSDK_TARGET_ARCH) \
@@ -87,6 +89,7 @@ $(INITRAMFS):
 		--argstr regressionTestPlatform $(REGRESSION_TEST_PLATFORM) \
 		--argstr dnsServer ${DNS_SERVER} \
 		--arg smp $(SMP) \
+		--arg-from-file authorized_keys $(AUTHORIZED_KEYS_FILE) \
 		--out-link $@ \
 		nix -A initramfs
 
@@ -155,6 +158,9 @@ initramfs_pkgs:
 		--arg enableBenchmarkTest true \
 		--out-link /nix/var/nix/gcroots/auto/x86_64-initramfs-with-benchmark \
 		-A initramfs-image
+
+$(AUTHORIZED_KEYS_FILE):
+	cat ${HOME}/.ssh/*.pub > $@
 
 $(EXT2_IMAGE):
 	@mkdir -p $(BUILD_DIR)

--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -161,7 +161,13 @@ initramfs_pkgs:
 
 $(AUTHORIZED_KEYS_FILE):
 	@mkdir -p $(BUILD_DIR)
-	cat ${HOME}/.ssh/*.pub > $@
+	@# If public SSH keys exist, put them in the authorized_keys file
+	@if ls ${HOME}/.ssh/*.pub > /dev/null 2> /dev/null; then \
+		cat ${HOME}/.ssh/*.pub > $@; \
+	else \
+		echo > $@; \
+		echo "Warning: No SSH key found. Logging in via Dropbear will be impossible."; \
+	fi
 
 $(EXT2_IMAGE):
 	@mkdir -p $(BUILD_DIR)

--- a/test/initramfs/README.md
+++ b/test/initramfs/README.md
@@ -103,6 +103,17 @@ Configuration files required by benchmarks or regression tests should be placed 
 
 If additional configuration files or directories are needed, ensure they are appropriately packaged by updating the `initramfs.nix` file.
 
+## SSH Server
+
+The `make run_kernel` guest environment contains an SSH server. To start it, run `start_dropbear.sh`
+in the guest. The server will then be available at port 22 in the host (and container) and
+accessible with `ssh localhost`. The server is configured with the user SSH keys of the container
+user and with passwords disabled. So you must create an SSH key in the container before calling
+`make run_kernel`. The guest SSH host keys are regenerated on each boot, so you will need to
+configure your SSH client appropriately.
+
+(As of writing, the `make run_nixos` guest environment does *not* have an SSH.)
+
 ## Notes for Developers
 
 - **Nix Usage**: Use `Nix` whenever possible to manage dependencies and builds for ease of maintenance and consistency.

--- a/test/initramfs/nix/default.nix
+++ b/test/initramfs/nix/default.nix
@@ -1,7 +1,8 @@
 { target ? "x86_64", enableBenchmarkTest ? false, enableConformanceTest ? false
 , enableRegressionTest ? false, conformanceTestSuite ? "ltp"
 , conformanceTestWorkDir ? "/tmp", regressionTestPlatform ? "asterinas"
-, dnsServer ? "none", smp ? 1, initramfsCompressed ? true, }:
+, dnsServer ? "none", smp ? 1, initramfsCompressed ? true
+, authorized_keys ? ""}:
 let
   crossSystem.config = if target == "x86_64" then
     "x86_64-unknown-linux-gnu"
@@ -39,6 +40,7 @@ in rec {
     conformance = if enableConformanceTest then conformance else null;
     regression = if enableRegressionTest then regression else null;
     dnsServer = dnsServer;
+    authorized_keys = authorized_keys;
   };
   initramfs-image = pkgs.callPackage ./initramfs-image.nix {
     inherit initramfs;

--- a/test/initramfs/nix/default.nix
+++ b/test/initramfs/nix/default.nix
@@ -1,8 +1,8 @@
 { target ? "x86_64", enableBenchmarkTest ? false, enableConformanceTest ? false
 , enableRegressionTest ? false, conformanceTestSuite ? "ltp"
 , conformanceTestWorkDir ? "/tmp", regressionTestPlatform ? "asterinas"
-, dnsServer ? "none", smp ? 1, initramfsCompressed ? true
-, authorized_keys ? ""}:
+, dnsServer ? "none", smp ? 1, initramfsCompressed ? true, authorized_keys ? ""
+}:
 let
   crossSystem.config = if target == "x86_64" then
     "x86_64-unknown-linux-gnu"

--- a/test/initramfs/nix/dropbear-conf.nix
+++ b/test/initramfs/nix/dropbear-conf.nix
@@ -1,17 +1,17 @@
 { lib, pkgs, stdenvNoCC, authorized_keys ? "" }:
 let
   start_dropbear_sh = builtins.toFile "start_dropbear.sh" ''
-# Launcher script for dropbear
+    # Launcher script for dropbear
 
-# Generate host keys
-mkdir -p /etc/dropbear
-dropbearkey -t rsa -f /etc/dropbear/dropbear_rsa_host_key
-dropbearkey -t ecdsa -f /etc/dropbear/dropbear_ecdsa_host_key
-dropbearkey -t ed25519 -f /etc/dropbear/dropbear_ed25519_host_key
+    # Generate host keys
+    mkdir -p /etc/dropbear
+    dropbearkey -t rsa -f /etc/dropbear/dropbear_rsa_host_key
+    dropbearkey -t ecdsa -f /etc/dropbear/dropbear_ecdsa_host_key
+    dropbearkey -t ed25519 -f /etc/dropbear/dropbear_ed25519_host_key
 
-# Start server with passwork logins disabled
-dropbear -s -p 10.0.2.15:22
-'';
+    # Start server with passwork logins disabled
+    dropbear -s -p 10.0.2.15:22
+  '';
   authorized_keys_file = builtins.toFile "authorized_keys" authorized_keys;
 in stdenvNoCC.mkDerivation {
   name = "dropbear-conf";
@@ -25,5 +25,5 @@ in stdenvNoCC.mkDerivation {
     mkdir -p $out/bin
     cp ${start_dropbear_sh} $out/bin/start_dropbear.sh
     chmod a+x $out/bin/start_dropbear.sh
-    '';
+  '';
 }

--- a/test/initramfs/nix/dropbear-conf.nix
+++ b/test/initramfs/nix/dropbear-conf.nix
@@ -1,0 +1,34 @@
+{ lib, pkgs, stdenvNoCC, authorized_keys ? "" }:
+let
+  start_dropbear_sh = builtins.toFile "start_dropbear.sh" ''
+# Launcher script for dropbear
+#
+# It generates keys and caches them in /ext2. This means they will often be retained over reboots.
+
+mkdir -p /ext2/etc/dropbear
+# Generate keys if they don't already exist.
+test /ext2/etc/dropbear/dropbear_rsa_host_key || dropbearkey -t rsa -f /ext2/etc/dropbear/dropbear_rsa_host_key
+test /ext2/etc/dropbear/dropbear_ecdsa_host_key || dropbearkey -t ecdsa -f /ext2/etc/dropbear/dropbear_ecdsa_host_key
+test /ext2/etc/dropbear/dropbear_ed25519_host_key || dropbearkey -t ed25519 -f /ext2/etc/dropbear/dropbear_ed25519_host_key
+
+# Copy keys into the actual /etc
+mkdir -p /etc/dropbear
+cp /ext2/etc/dropbear/* /etc/dropbear/
+
+dropbear -s -p 10.0.2.15:22
+'';
+  authorized_keys_file = builtins.toFile "authorized_keys" authorized_keys;
+in stdenvNoCC.mkDerivation {
+  name = "dropbear-conf";
+  buildCommand = ''
+    # Insert the provided user keys into the image
+    mkdir -p $out/.ssh
+    cp ${authorized_keys_file} $out/.ssh/authorized_keys
+    chmod 700 $out/.ssh
+    chmod 600 $out/.ssh/authorized_keys
+
+    mkdir -p $out/bin
+    cp ${start_dropbear_sh} $out/bin/start_dropbear.sh
+    chmod a+x $out/bin/start_dropbear.sh
+    '';
+}

--- a/test/initramfs/nix/dropbear-conf.nix
+++ b/test/initramfs/nix/dropbear-conf.nix
@@ -2,19 +2,14 @@
 let
   start_dropbear_sh = builtins.toFile "start_dropbear.sh" ''
 # Launcher script for dropbear
-#
-# It generates keys and caches them in /ext2. This means they will often be retained over reboots.
 
-mkdir -p /ext2/etc/dropbear
-# Generate keys if they don't already exist.
-test /ext2/etc/dropbear/dropbear_rsa_host_key || dropbearkey -t rsa -f /ext2/etc/dropbear/dropbear_rsa_host_key
-test /ext2/etc/dropbear/dropbear_ecdsa_host_key || dropbearkey -t ecdsa -f /ext2/etc/dropbear/dropbear_ecdsa_host_key
-test /ext2/etc/dropbear/dropbear_ed25519_host_key || dropbearkey -t ed25519 -f /ext2/etc/dropbear/dropbear_ed25519_host_key
-
-# Copy keys into the actual /etc
+# Generate host keys
 mkdir -p /etc/dropbear
-cp /ext2/etc/dropbear/* /etc/dropbear/
+dropbearkey -t rsa -f /etc/dropbear/dropbear_rsa_host_key
+dropbearkey -t ecdsa -f /etc/dropbear/dropbear_ecdsa_host_key
+dropbearkey -t ed25519 -f /etc/dropbear/dropbear_ed25519_host_key
 
+# Start server with passwork logins disabled
 dropbear -s -p 10.0.2.15:22
 '';
   authorized_keys_file = builtins.toFile "authorized_keys" authorized_keys;

--- a/test/initramfs/nix/initramfs-image.nix
+++ b/test/initramfs/nix/initramfs-image.nix
@@ -5,6 +5,7 @@ stdenvNoCC.mkDerivation {
   buildCommand = ''
     pushd $(mktemp -d)
     cp -r ${initramfs}/* ./
+    cp -r ${initramfs}/.ssh ./
     chmod -R 0755 benchmark
     chmod -R 0755 etc
     chmod -R 0755 opt

--- a/test/initramfs/nix/initramfs.nix
+++ b/test/initramfs/nix/initramfs.nix
@@ -7,6 +7,7 @@ let
     root = ./../etc;
     fileset = ./../etc;
   };
+  # The openssh dependency is only for the sftp-server binary. The actual ssh server is still provided by dropbear.
   openssh = pkgs.openssh;
   dropbear = pkgs.dropbear.override { enableSCP = true; sftpPath = "/bin/sftp-server"; };
   dropbear_conf = pkgs.callPackage ./dropbear-conf.nix { authorized_keys = authorized_keys; };

--- a/test/initramfs/nix/initramfs.nix
+++ b/test/initramfs/nix/initramfs.nix
@@ -1,5 +1,5 @@
 { lib, pkgs, stdenvNoCC, fetchFromGitHub, hostPlatform, writeClosure, busybox
-, benchmark, conformance, regression, dnsServer, }:
+, benchmark, conformance, regression, dnsServer, authorized_keys }:
 let
   boot_hello = builtins.path { path = ./../src/boot_hello.sh; };
   init = builtins.path { path = ./../src/init; };
@@ -7,6 +7,9 @@ let
     root = ./../etc;
     fileset = ./../etc;
   };
+  openssh = pkgs.openssh;
+  dropbear = pkgs.dropbear.override { enableSCP = true; sftpPath = "/bin/sftp-server"; };
+  dropbear_conf = pkgs.callPackage ./dropbear-conf.nix { authorized_keys = authorized_keys; };
   gvisor_libs = if conformance != null && conformance.testSuite == "gvisor" then
     builtins.path {
       name = "gvisor-libs";
@@ -17,7 +20,7 @@ let
   resolv_conf = pkgs.callPackage ./resolv_conf.nix { dnsServer = dnsServer; };
   # Whether the initramfs should include evtest, a common tool to debug input devices (`/dev/input/eventX`)
   is_evtest_included = false;
-  all_pkgs = [ busybox etc resolv_conf ]
+  all_pkgs = [ busybox dropbear openssh etc resolv_conf ]
     ++ lib.optionals (benchmark != null) [ benchmark.package ]
     ++ lib.optionals (conformance != null) [ conformance.package ]
     ++ lib.optionals (regression != null) [ regression.package ]
@@ -33,6 +36,8 @@ in stdenvNoCC.mkDerivation {
     ln -sfn usr/lib $out/lib
     ln -sfn usr/lib64 $out/lib64
     cp -r ${busybox}/bin/* $out/bin/
+    cp -r ${dropbear}/bin/* $out/bin/
+    cp -r ${openssh}/libexec/sftp-server $out/bin/
     ${lib.optionalString is_evtest_included ''
       cp -r ${pkgs.evtest}/bin/* $out/bin/
     ''}
@@ -43,6 +48,8 @@ in stdenvNoCC.mkDerivation {
     cp -r ${etc}/* $out/etc/
 
     cp ${resolv_conf}/resolv.conf $out/etc/
+    cp -r ${dropbear_conf}/.ssh $out/
+    cp -r ${dropbear_conf}/bin/* $out/bin/
 
     ${lib.optionalString (regression != null) ''
       cp -r ${regression.package}/* $out/test/

--- a/test/initramfs/nix/initramfs.nix
+++ b/test/initramfs/nix/initramfs.nix
@@ -9,8 +9,12 @@ let
   };
   # The openssh dependency is only for the sftp-server binary. The actual ssh server is still provided by dropbear.
   openssh = pkgs.openssh;
-  dropbear = pkgs.dropbear.override { enableSCP = true; sftpPath = "/bin/sftp-server"; };
-  dropbear_conf = pkgs.callPackage ./dropbear-conf.nix { authorized_keys = authorized_keys; };
+  dropbear = pkgs.dropbear.override {
+    enableSCP = true;
+    sftpPath = "/bin/sftp-server";
+  };
+  dropbear_conf =
+    pkgs.callPackage ./dropbear-conf.nix { authorized_keys = authorized_keys; };
   gvisor_libs = if conformance != null && conformance.testSuite == "gvisor" then
     builtins.path {
       name = "gvisor-libs";


### PR DESCRIPTION
* Installs dropbear via nix
* Supports SCP and SFTP (via openssh's sftp-server)
* Includes a script `start_dropbear.sh` to setup host keys and start the server.
* Injects the users SSH keys into the image so the user can login.