### PR TITLE
Add Python, pip, and CBOR2 to guest environment.

### DIFF
--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -7,6 +7,8 @@ ENABLE_CONFORMANCE_TEST ?= false
 CONFORMANCE_TEST_SUITE ?= ltp
 CONFORMANCE_TEST_WORKDIR ?= /tmp
 ENABLE_REGRESSION_TEST ?= false
+ENABLE_PYTHON ?= false
+
 # Specify platform macros when building regression tests (supported: asterinas, linux).
 # - asterinas: Define both `__asterinas__` and `__linux__`. Tests may fail in Linux.
 # - linux: Define only `__linux__`. Tests may fail in Asterinas.
@@ -41,6 +43,12 @@ else
 ENABLE_BENCHMARK_TEST = true
 endif
 
+ifneq ($(filter 1 true,$(ENABLE_PYTHON)),)
+ENABLE_NIX_PYTHON := true
+else
+ENABLE_NIX_PYTHON := false
+endif
+
 # Decreases the level of verbosity of diagnostic messages from Nix.
 ifeq ($(VERBOSE), 0)
 NIX_QUIET = --quiet -Q
@@ -66,6 +74,7 @@ $(INITRAMFS_IMAGE): $(INITRAMFS)
 		--arg enableBenchmarkTest $(ENABLE_BENCHMARK_TEST) \
 		--arg enableConformanceTest $(ENABLE_CONFORMANCE_TEST) \
 		--arg enableRegressionTest $(ENABLE_REGRESSION_TEST) \
+		--arg enablePython $(ENABLE_NIX_PYTHON) \
 		--argstr conformanceTestSuite $(CONFORMANCE_TEST_SUITE) \
 		--argstr conformanceTestWorkDir $(CONFORMANCE_TEST_WORKDIR) \
 		--argstr regressionTestPlatform $(REGRESSION_TEST_PLATFORM) \
@@ -84,6 +93,7 @@ $(INITRAMFS): $(AUTHORIZED_KEYS_FILE)
 		--arg enableBenchmarkTest $(ENABLE_BENCHMARK_TEST) \
 		--arg enableConformanceTest $(ENABLE_CONFORMANCE_TEST) \
 		--arg enableRegressionTest $(ENABLE_REGRESSION_TEST) \
+		--arg enablePython $(ENABLE_NIX_PYTHON) \
 		--argstr conformanceTestSuite $(CONFORMANCE_TEST_SUITE) \
 		--argstr conformanceTestWorkDir $(CONFORMANCE_TEST_WORKDIR) \
 		--argstr regressionTestPlatform $(REGRESSION_TEST_PLATFORM) \
@@ -102,6 +112,7 @@ x86_64_pkgs:
 		--argstr target x86_64 \
 		--arg enableBenchmarkTest true \
 		--arg enableConformanceTest true \
+		--arg enablePython true
 		--out-link /nix/var/nix/gcroots/auto/x86_64-pkgs \
 		-A busybox \
 		-A benchmark.fio \

--- a/test/initramfs/README.md
+++ b/test/initramfs/README.md
@@ -114,6 +114,26 @@ configure your SSH client appropriately.
 
 (As of writing, the `make run_nixos` guest environment does *not* have an SSH.)
 
+## Python
+
+The `make run_kernel` guest environment can be configured with Python. It is not included by
+default. To enable Python, set `ENABLE_PYTHON=1` when you invoke `make`.
+
+```shell
+make run_kernel ENABLE_PYTHON=1
+```
+
+Python is not included by default because it increases the size of the initramfs by more than a 3
+times. This increases the initramfs load time very significantly.
+
+When enabled, the `python` binary is available and a small selection of packages (see
+`test/initramfs/nix/initramfs.nix`). The generated launchers for Python scripts do not work on
+busybox, but in many cases you can run the same tool using `python -m <package>`. (Notably, the
+CBOR2 tool is `python -m cbor2.tool`.) 
+
+`pip` is installed, but most normal operations depend on network access which require separate
+configuration. You should use a virtual environment (`python -m venv`) if you wish to use `pip`.
+
 ## Notes for Developers
 
 - **Nix Usage**: Use `Nix` whenever possible to manage dependencies and builds for ease of maintenance and consistency.

--- a/test/initramfs/nix/default.nix
+++ b/test/initramfs/nix/default.nix
@@ -2,7 +2,7 @@
 , enableRegressionTest ? false, conformanceTestSuite ? "ltp"
 , conformanceTestWorkDir ? "/tmp", regressionTestPlatform ? "asterinas"
 , dnsServer ? "none", smp ? 1, initramfsCompressed ? true, authorized_keys ? ""
-}:
+, enablePython ? false }:
 let
   crossSystem.config = if target == "x86_64" then
     "x86_64-unknown-linux-gnu"
@@ -41,6 +41,7 @@ in rec {
     regression = if enableRegressionTest then regression else null;
     dnsServer = dnsServer;
     authorized_keys = authorized_keys;
+    enablePython = enablePython;
   };
   initramfs-image = pkgs.callPackage ./initramfs-image.nix {
     inherit initramfs;

--- a/test/initramfs/nix/initramfs.nix
+++ b/test/initramfs/nix/initramfs.nix
@@ -1,5 +1,6 @@
 { lib, pkgs, stdenvNoCC, fetchFromGitHub, hostPlatform, writeClosure, busybox
-, benchmark, conformance, regression, dnsServer, authorized_keys }:
+, benchmark, conformance, regression, dnsServer, authorized_keys, enablePython
+}:
 let
   boot_hello = builtins.path { path = ./../src/boot_hello.sh; };
   init = builtins.path { path = ./../src/init; };
@@ -7,6 +8,8 @@ let
     root = ./../etc;
     fileset = ./../etc;
   };
+  python3 =
+    pkgs.python312.withPackages (python-pkgs: with python-pkgs; [ pip cbor2 ]);
   # The openssh dependency is only for the sftp-server binary. The actual ssh server is still provided by dropbear.
   openssh = pkgs.openssh;
   dropbear = pkgs.dropbear.override {
@@ -26,6 +29,7 @@ let
   # Whether the initramfs should include evtest, a common tool to debug input devices (`/dev/input/eventX`)
   is_evtest_included = false;
   all_pkgs = [ busybox dropbear openssh etc resolv_conf ]
+    ++ lib.optionals enablePython [ python3 ]
     ++ lib.optionals (benchmark != null) [ benchmark.package ]
     ++ lib.optionals (conformance != null) [ conformance.package ]
     ++ lib.optionals (regression != null) [ regression.package ]
@@ -79,11 +83,19 @@ in stdenvNoCC.mkDerivation {
       cp -L ${gvisor_libs}/libm.so.6 $out/lib/x86_64-linux-gnu/libm.so.6
     ''}
 
+    mkdir -p $out/nix/store
+
+    ${
+      lib.optionalString enablePython ''
+        cp -r ${python3} $out/nix/store/
+        cp ${python3}/bin/* $out/bin/
+      ''
+    }    
+
     # Use `writeClosure` to retrieve all dependencies of the specified packages.
     # This will generate a text file containing the complete closure of the packages,
     # including the packages themselves.
     # The output of `writeClosure` is equivalent to `nix-store -q --requisites`.
-    mkdir -p $out/nix/store
     pkg_path=${lib.strings.concatStringsSep ":" all_pkgs}
     while IFS= read -r dep_path; do
       if [[ "$pkg_path" == *"$dep_path"* ]]; then


### PR DESCRIPTION
Python is added via Nix and must be explicitly enabled with `ENABLE_PYTHON=1`, because it triples the size of the initramfs.

This contains no tests for Python in the guest. That should be included in some part of the integration tests. As of now, this is primarily a development tool, so leaving it without automatic testing is probably OK.

`pip` is installed, but most normal operations depend on network access which doesn't work in the current default configuration.
