### PR TITLE
Fix make check BASELINE_ASTERINAS=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ $(CARGO_OSDK): $(OSDK_SRC_FILES)
 
 .PHONY: check_osdk
 check_osdk:
-	@./tools/clippy_check.sh osdk $(CLIPPY_COMMON_ARGS)
+	@./tools/clippy_check.sh osdk -- $(CLIPPY_COMMON_ARGS)
 
 .PHONY: test_osdk
 test_osdk:
@@ -493,7 +493,7 @@ check: $(CARGO_OSDK)
 	done
 	@
 	@# Check compilation of the Rust code
-	@OSDK_TARGET_ARCH="$(OSDK_TARGET_ARCH)" ./tools/clippy_check.sh workspace $(CLIPPY_COMMON_ARGS)
+	@OSDK_TARGET_ARCH="$(OSDK_TARGET_ARCH)" ./tools/clippy_check.sh workspace -- $(CLIPPY_COMMON_ARGS)
 	@
 	@# Check formatting issues of the C code and Nix files (regression tests)
 	@$(MAKE) --no-print-directory -C test/initramfs check

--- a/tools/clippy_check.sh
+++ b/tools/clippy_check.sh
@@ -10,17 +10,18 @@ LINUX_BZIMAGE_SETUP_DIR="ostd/libs/linux-bzimage/setup"
 usage() {
     cat <<'EOF'
 Usage:
-  ./tools/clippy_check.sh osdk
+  ./tools/clippy_check.sh osdk [ARGS]
       Runs `cargo clippy --all-targets --no-deps` for the standalone `osdk`
-      crate.
+      crate, passing [ARGS] to cargo clippy.
 
   [OSDK_TARGET_ARCH=x86_64|riscv64|loongarch64] \
-  ./tools/clippy_check.sh workspace
+  ./tools/clippy_check.sh workspace [ARGS]
       Runs the workspace clippy checks used by `make check`.
       This checks:
         - workspace `default-members` with `cargo osdk clippy`
         - non-default workspace members with `cargo clippy --all-targets`
         - `ostd/libs/linux-bzimage/setup` separately on `x86_64`
+      [ARGS] are passed to the underlying cargo/cargo osdk clippy calls.
 
 Options:
   -h, --help
@@ -59,7 +60,7 @@ run_check_osdk() {
     echo "Checking osdk"
     (
         cd "$PROJECT_ROOT/osdk"
-        RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --no-deps
+        RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --no-deps "$@"
     )
 }
 
@@ -73,8 +74,8 @@ run_workspace_clippy() {
     echo "Checking default workspace members"
     (
         cd "$PROJECT_ROOT"
-        RUSTFLAGS="-Dwarnings" cargo osdk clippy -- --no-deps
-        RUSTFLAGS="-Dwarnings" cargo osdk clippy --ktests -- --no-deps
+        RUSTFLAGS="-Dwarnings" cargo osdk clippy -- --no-deps "$@"
+        RUSTFLAGS="-Dwarnings" cargo osdk clippy --ktests -- --no-deps "$@"
     )
 
     build_package_args "--non-default-ones" non_default_package_args
@@ -93,7 +94,7 @@ run_workspace_clippy() {
         echo "Checking non-default workspace members"
         (
             cd "$PROJECT_ROOT"
-            RUSTFLAGS="-Dwarnings" cargo clippy "${filtered_non_default_package_args[@]}" --all-targets --no-deps
+            RUSTFLAGS="-Dwarnings" cargo clippy "${filtered_non_default_package_args[@]}" --all-targets --no-deps "$@"
         )
     fi
 
@@ -103,24 +104,25 @@ run_workspace_clippy() {
         echo "Checking ${LINUX_BZIMAGE_SETUP_DIR}"
         (
             cd "$PROJECT_ROOT/$LINUX_BZIMAGE_SETUP_DIR"
-            RUSTFLAGS="-Dwarnings" cargo osdk clippy -- --no-deps
-            RUSTFLAGS="-Dwarnings" cargo osdk clippy --ktests -- --no-deps
+            RUSTFLAGS="-Dwarnings" cargo osdk clippy -- --no-deps "$@"
+            RUSTFLAGS="-Dwarnings" cargo osdk clippy --ktests -- --no-deps "$@"
         )
     fi
 }
 
 main() {
     local mode="${1:-}"
+    shift
 
     case "$mode" in
         -h|--help)
             usage
             ;;
         osdk)
-            run_check_osdk
+            run_check_osdk "$@"
             ;;
         workspace)
-            run_workspace_clippy
+            run_workspace_clippy "$@"
             ;;
         *)
             usage >&2


### PR DESCRIPTION
The merge broke this such that `make check BASELINE_ASTERINAS=1` actually checked the ORPC version (the same as `make check`). This fixes it by reenabling passing the `cargo check` args through from the makefile to cargo.