### PR TITLE
Disable legacy32 boot protocol test in CI.

### DIFF
--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -78,7 +78,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { variant: 'legacy32', boot_protocol: 'linux-legacy32', smp: 4 }
+          # TODO: Reenable or explicitly decide not to support it.
+          # - { variant: 'legacy32', boot_protocol: 'linux-legacy32', smp: 4 }
           - { variant: 'multiboot2-smp4', boot_protocol: 'multiboot', smp: 4 }
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This move is consistently hanging in CI. We will reevaluate later.