### PR TITLE
Improve error reporting for non-fatal kernel code panics.

### DIFF
--- a/kernel/src/thread/kernel_thread.rs
+++ b/kernel/src/thread/kernel_thread.rs
@@ -2,6 +2,7 @@
 
 use ostd::{
     cpu::CpuSet,
+    ignore_err,
     task::{Task, TaskOptions},
 };
 
@@ -54,7 +55,7 @@ impl ThreadOptions {
     pub fn build(mut self) -> Arc<Task> {
         let task_fn = self.func.take().unwrap();
         let thread_fn = move || {
-            let _ = oops::catch_panics_as_oops(task_fn);
+            ignore_err!(oops::catch_panics_as_oops(task_fn));
             // Ensure that the thread exits.
             current_thread!().exit();
         };

--- a/kernel/src/thread/task.rs
+++ b/kernel/src/thread/task.rs
@@ -122,7 +122,9 @@ pub fn create_new_user_task(
     TaskOptions::new(move || {
         // TODO: If a kernel "oops" is caught, we should kill the entire
         // process rather than just ending the thread.
-        let _ = oops::catch_panics_as_oops(user_task_func);
+        if let Err(e) = oops::catch_panics_as_oops(user_task_func) {
+            error!("Panic while executing user thread: {}\n(FIXME: The process was not killed, so other parts of the system may hang.)", e);
+        }
     })
     .data(thread_ref)
     .local_data(thread_local)


### PR DESCRIPTION
Upstream asterinas aborts immediately when there is a panic. We allow execution to continue. This means that we need to report that since it can leave the system in a weird state.

Closes: https://github.com/ldos-project/asterinas/issues/241