### PR TITLE
Add mariposa_data_capture regression smoke test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ CARGO_OSDK_BUILD_ARGS += --init-args="/opt/run_conformance_test.sh"
 else ifeq ($(AUTO_TEST), regression)
 ENABLE_REGRESSION_TEST := true
 CARGO_OSDK_BUILD_ARGS += --kcmd-args="INTEL_TDX=$(INTEL_TDX)"
+CARGO_OSDK_BUILD_ARGS += --kcmd-args="data_capture.regression_smoke=1"
 CARGO_OSDK_BUILD_ARGS += --init-args="/test/run_regression_test.sh"
 else ifeq ($(AUTO_TEST), raid)
 ENABLE_REGRESSION_TEST := true

--- a/kernel/comps/mariposa_data_capture/src/lib.rs
+++ b/kernel/comps/mariposa_data_capture/src/lib.rs
@@ -23,6 +23,30 @@
 //! The set of OQueue paths is only for convenience, so it can be incomplete or missing. This may be
 //! because of set of OQueues was not known when output started.
 //!
+//! ## Userspace decoding example
+//!
+//! After the guest has written capture data (and synced), decode the device image
+//! on the host:
+//!
+//! `	ext
+//! python3 kernel/comps/mariposa_data_capture/python/decode_mariposa_data.py \
+//!     test/initramfs/build/capture.img --preview 5
+//! `
+//!
+//! Or dump every capture file to JSONL:
+//!
+//! `	ext
+//! python3 kernel/comps/mariposa_data_capture/python/decode_mariposa_data.py \
+//!     test/initramfs/build/capture.img --output-dir /tmp/capture-out
+//! `
+//!
+//! The regression suite also exercises this path end-to-end: with
+//! data_capture.regression_smoke=1 the kernel writes three known u32
+//! samples (42, 100, 200) to a capture file named 
+egression.smoke,
+//! and 	est/initramfs/src/regression/mariposa_data_capture checks that the
+//! guest-visible block device contains the format magic and those CBOR values.
+//!
 //! Note: The output format is not particularly space efficient because it includes the field names
 //! of structs every time they are serialized. If this becomes a problem there are a few options: 1)
 //! use [`#[serde(rename=...)`](https://serde.rs/field-attrs.html) to give shorter field names in

--- a/kernel/src/data_capture.rs
+++ b/kernel/src/data_capture.rs
@@ -6,7 +6,7 @@ use core::{result::Result, time::Duration};
 
 use aster_block::BlockDevice;
 use ostd::{
-    error, ignore_err, info, new_server,
+    error, ignore_err, info, new_server, path,
     orpc::{
         framework::{notifier::Notifier as _, spawn_thread},
         oqueue::{Element, OQueueBase as _, ObservationQuery, registry::lookup_by_type},
@@ -108,6 +108,32 @@ pub(super) fn start_capture_devices() {
         DataCaptureManager::spawn(Duration::from_secs_f32(secs));
     }
 }
+
+/// When \data_capture.regression_smoke\ is set, write a tiny known capture so
+/// userspace regression tests can decode the on-disk format without needing a
+/// full scheduler/IO workload.
+pub(super) fn maybe_regression_smoke_capture() {
+    let enabled = kcmdline::get_kernel_cmd_line()
+        .and_then(|cl| cl.get_module_arg_by_name::<bool>("data_capture", "regression_smoke"))
+        .unwrap_or(false);
+    if !enabled {
+        return;
+    }
+
+    let Some(capture_file) = new_data_capture_file::<u32>(mariposa_data_capture::FileDescriptor {
+        path: path!(regression.smoke),
+        length: 64 * 1024,
+    }) else {
+        error!("[kernel] data_capture.regression_smoke enabled but no capture device");
+        return;
+    };
+
+    ignore_err!(capture_file.start());
+    ignore_err!(capture_file.write_values(Box::new([42u32, 100u32, 200u32].into_iter())));
+    ignore_err!(capture_file.sync());
+    info!("[kernel] Wrote data_capture regression smoke samples");
+}
+
 
 /// Create a new data capture file for OQueues.
 pub fn new_data_capture_file<T: Serialize + Copy + Send + 'static>(

--- a/kernel/src/init.rs
+++ b/kernel/src/init.rs
@@ -360,6 +360,7 @@ fn init_in_first_kthread(path_resolver: &PathResolver) {
     #[cfg(not(baseline_asterinas))]
     {
         data_capture::start_capture_devices();
+        data_capture::maybe_regression_smoke_capture();
     }
 
     crate::device::init_in_first_kthread();

--- a/test/initramfs/nix/regression/default.nix
+++ b/test/initramfs/nix/regression/default.nix
@@ -20,6 +20,7 @@ let
     "security"
     "time"
     "raid1"
+    "mariposa_data_capture"
   ];
 
   tdxAttest = callPackage ./tdx-attest.nix { };

--- a/test/initramfs/src/regression/Makefile
+++ b/test/initramfs/src/regression/Makefile
@@ -24,6 +24,7 @@ SUBDIRS := \
 	security \
 	time \
 	raid1 \
+	mariposa_data_capture \
 
 ifeq ($(HOST_PLATFORM), x86_64-linux)
 SUBDIRS += intel_tdx

--- a/test/initramfs/src/regression/mariposa_data_capture/Makefile
+++ b/test/initramfs/src/regression/mariposa_data_capture/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MPL-2.0
+
+include ../common/Makefile

--- a/test/initramfs/src/regression/mariposa_data_capture/decode_smoke.c
+++ b/test/initramfs/src/regression/mariposa_data_capture/decode_smoke.c
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/*
+ * Userspace side of the mariposa_data_capture regression smoke test.
+ *
+ * The kernel writes a tiny capture file (path regression.smoke) with the
+ * known u32 samples 42, 100, 200 when data_capture.regression_smoke=1.
+ * This program opens the capture block device, finds the Mariposa magic,
+ * and checks that those CBOR-encoded samples are present.
+ *
+ * Device naming: QEMU attaches the capture image last among the standard
+ * virtio-blk disks (see tools/qemu_args.sh), so it appears as /dev/vdg and
+ * is selected via data_capture.device=vdg in OSDK.toml.
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../common/test.h"
+
+#define CAPTURE_DEV "/dev/vdg"
+#define BLOCK_SIZE 4096
+/* Directory is one block; smoke file starts at the next block. */
+#define SMOKE_FILE_OFFSET BLOCK_SIZE
+#define READ_LEN (BLOCK_SIZE * 2)
+
+static const unsigned char MAGIC[] = "MARIPOSALDOSDATA"; /* plus trailing NUL in file */
+/* CBOR major type 0, additional 24, then one-byte value: 42, 100, 200 */
+static const unsigned char EXPECTED_SAMPLES[] = { 0x18, 0x2a, 0x18, 0x64, 0x18, 0xc8 };
+
+static int memmem_idx(const unsigned char *hay, size_t hay_len,
+		      const unsigned char *needle, size_t needle_len)
+{
+	size_t i;
+
+	if (needle_len > hay_len)
+		return -1;
+	for (i = 0; i + needle_len <= hay_len; i++) {
+		if (memcmp(hay + i, needle, needle_len) == 0)
+			return (int)i;
+	}
+	return -1;
+}
+
+FN_TEST(capture_device_has_magic_and_samples)
+{
+	int fd;
+	unsigned char *buf;
+	ssize_t n;
+	int magic_at;
+	int samples_at;
+
+	buf = NULL;
+	if (posix_memalign((void **)&buf, BLOCK_SIZE, READ_LEN) != 0) {
+		fprintf(stderr, "posix_memalign failed\\n");
+		exit(EXIT_FAILURE);
+	}
+
+	fd = open(CAPTURE_DEV, O_RDONLY);
+	if (fd < 0) {
+		if (errno == ENOENT || errno == ENODEV || errno == ENXIO) {
+			fprintf(stderr,
+				"mariposa_data_capture tests skipped: open('%s'): %s\\n",
+				CAPTURE_DEV, strerror(errno));
+			free(buf);
+			exit(EXIT_SUCCESS);
+		}
+		TEST_SUCC(fd);
+		free(buf);
+		return;
+	}
+
+	/* Read the directory block plus the first capture-file block. */
+	n = pread(fd, buf, READ_LEN, 0);
+	TEST_RES(n, n == (ssize_t)READ_LEN);
+	close(fd);
+
+	magic_at = memmem_idx(buf, (size_t)n, MAGIC, sizeof(MAGIC) - 1);
+	if (magic_at < 0) {
+		/*
+		 * Smoke capture not present (kernel not built with the kcmd
+		 * flag). Skip rather than fail so the suite stays usable
+		 * outside AUTO_TEST=regression.
+		 */
+		fprintf(stderr,
+			"mariposa_data_capture tests skipped: no MARIPOSALDOSDATA magic on %s\\n",
+			CAPTURE_DEV);
+		free(buf);
+		exit(EXIT_SUCCESS);
+	}
+
+	/* Magic should land in the file region (after the directory block). */
+	TEST_RES(magic_at, magic_at >= (int)SMOKE_FILE_OFFSET);
+
+	samples_at = memmem_idx(buf, (size_t)n, EXPECTED_SAMPLES,
+				sizeof(EXPECTED_SAMPLES));
+	TEST_RES(samples_at, samples_at > magic_at);
+
+	printf("mariposa_data_capture: found magic at %d and samples at %d\\n",
+	       magic_at, samples_at);
+	free(buf);
+}
+END_TEST()

--- a/test/initramfs/src/regression/mariposa_data_capture/run_test.sh
+++ b/test/initramfs/src/regression/mariposa_data_capture/run_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+./decode_smoke


### PR DESCRIPTION
## Summary
Adds an end-to-end regression for `mariposa_data_capture`: a small kernel path writes known samples to the capture device, and a userspace test decodes the on-disk format.

## Changes
- Kernel: when `data_capture.regression_smoke=1`, write `u32` samples `42`, `100`, `200` into a capture file named `regression.smoke` (via existing `write_values` / sync APIs)
- Userspace: new `test/initramfs/src/regression/mariposa_data_capture` suite opens `/dev/vdg`, finds `MARIPOSALDOSDATA` magic, and checks for the CBOR sample bytes
- Wire suite into regression Makefile + Nix package list
- Enable the kcmd flag for `AUTO_TEST=regression`
- Document host-side decode examples in the component rustdoc

## Notes
- Uses as little new kernel code as possible (no custom OQueue plumbing; reuses `write_values`)
- Userspace test skips cleanly if the capture device or magic is absent (manual boots without the kcmd flag)

## Test plan
- [ ] `make run AUTO_TEST=regression` (or equivalent) and confirm the new suite passes
- [ ] Optional: `decode_mariposa_data.py test/initramfs/build/capture.img --preview 5` after a smoke run

Fixes #283