### PR TITLE
Replace prepare_ycsb() with ycsb nix file: update docker image references (2/3)

### DIFF
--- a/.devcontainer/devcontainer.template.json
+++ b/.devcontainer/devcontainer.template.json
@@ -1,6 +1,6 @@
 {
   "name": "Asterinas Dev Container",
-  "image": "ldosproject/asterinas:0.18.0-ldos-20260818",
+  "image": "ldosproject/asterinas:0.18.0-ldos-20260820",
   // Mount the workspace and the `/dev` directory
   "workspaceFolder": "/root/asterinas",
   "workspaceMount": "source=${localWorkspaceFolder},target=/root/asterinas,type=bind",

--- a/.github/workflows/benchmark_x86.yml
+++ b/.github/workflows/benchmark_x86.yml
@@ -109,7 +109,7 @@ jobs:
       max-parallel: 1
     timeout-minutes: 60
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
 
     steps:

--- a/.github/workflows/benchmark_x86_tdx.yml
+++ b/.github/workflows/benchmark_x86_tdx.yml
@@ -108,7 +108,7 @@ jobs:
       max-parallel: 1
     timeout-minutes: 60
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
 
     steps:

--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -21,7 +21,7 @@ jobs:
   check_api_docs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: ldosproject/asterinas:0.18.0-ldos-20260818
+    container: ldosproject/asterinas:0.18.0-ldos-20260820
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish_aster_nixos.yml
+++ b/.github/workflows/publish_aster_nixos.yml
@@ -14,7 +14,7 @@ jobs:
   push-cachix:
     runs-on: ubuntu-4-cores-150GB-ssd
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
     timeout-minutes: 60
     steps:
@@ -95,7 +95,7 @@ jobs:
       - name: Build ISO
         uses: maus007/docker-run-action-fork@v1
         with:
-          image: ldosproject/asterinas:0.18.0-ldos-20260818
+          image: ldosproject/asterinas:0.18.0-ldos-20260820
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
           run: |
             export ASTER_BUILD_TIMESTAMP=`date '+%a %b %e %H:%M:%S %Z %Y'`

--- a/.github/workflows/publish_osdk_and_ostd.yml
+++ b/.github/workflows/publish_osdk_and_ostd.yml
@@ -20,7 +20,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: ldosproject/asterinas:0.18.0-ldos-20260818
+    container: ldosproject/asterinas:0.18.0-ldos-20260820
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish_sctrace.yml
+++ b/.github/workflows/publish_sctrace.yml
@@ -17,7 +17,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: ldosproject/asterinas:0.18.0-ldos-20260818
+    container: ldosproject/asterinas:0.18.0-ldos-20260820
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -19,7 +19,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: ldosproject/asterinas:0.18.0-ldos-20260818
+    container: ldosproject/asterinas:0.18.0-ldos-20260820
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/push_cachix_dev.yml
+++ b/.github/workflows/push_cachix_dev.yml
@@ -20,7 +20,7 @@ jobs:
   push-pkgs:
     runs-on: ubuntu-4-cores-150GB-ssd
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test_asterinas_vsock.yml
+++ b/.github/workflows/test_asterinas_vsock.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
             docker run \
               --privileged --network=host -v /dev:/dev \
-              -v ./:/root/asterinas ldosproject/asterinas:0.18.0-ldos-20260818 \
+              -v ./:/root/asterinas ldosproject/asterinas:0.18.0-ldos-20260820 \
               make run_kernel AUTO_TEST=vsock ENABLE_KVM=0 SCHEME=microvm RELEASE_MODE=1 &
       - name: Run Vsock Client on Host
         id: host_vsock_client

--- a/.github/workflows/test_iso_image.yml
+++ b/.github/workflows/test_iso_image.yml
@@ -19,7 +19,7 @@ jobs:
   iso-test:
     runs-on: ubuntu-4-cores-150GB-ssd
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test_loongarch.yml
+++ b/.github/workflows/test_loongarch.yml
@@ -11,7 +11,7 @@ jobs:
   basic-test:
     runs-on: ubuntu-latest
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
     strategy:
       matrix:

--- a/.github/workflows/test_nixos_full.yml
+++ b/.github/workflows/test_nixos_full.yml
@@ -190,7 +190,7 @@ jobs:
         timeout-minutes: ${{ matrix.test.timeout_minutes || 30 }}
         uses: maus007/docker-run-action-fork@v1
         with:
-          image: ldosproject/asterinas:0.18.0-ldos-20260818
+          image: ldosproject/asterinas:0.18.0-ldos-20260820
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
           run: |
             make nixos NIXOS_TEST_SUITE=${{ matrix.test.name }} NIXOS_DISK_SIZE_IN_MB=${{ matrix.test.disk_size }}

--- a/.github/workflows/test_nixos_minimal.yml
+++ b/.github/workflows/test_nixos_minimal.yml
@@ -36,7 +36,7 @@ jobs:
         timeout-minutes: 30
         uses: maus007/docker-run-action-fork@v1
         with:
-          image: ldosproject/asterinas:0.18.0-ldos-20260818
+          image: ldosproject/asterinas:0.18.0-ldos-20260820
           options: --privileged -v /dev:/dev -v ${{ github.workspace }}:/root/asterinas
           run: |
             make nixos NIXOS_TEST_SUITE=hello NIXOS_DISK_SIZE_IN_MB=6144

--- a/.github/workflows/test_riscv.yml
+++ b/.github/workflows/test_riscv.yml
@@ -13,7 +13,7 @@ jobs:
   basic-test:
     runs-on: ubuntu-latest
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
       volumes:
         # Map the following directories on the host into the container so that
@@ -40,7 +40,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
       volumes:
         # Map the following directories on the host into the container so that

--- a/.github/workflows/test_x86.yml
+++ b/.github/workflows/test_x86.yml
@@ -18,7 +18,7 @@ jobs:
   basic-test:
     runs-on: ubuntu-latest
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
       volumes:
         # Map the following directories on the host into the container so that
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ['ldosproject/asterinas:0.18.0-ldos-20260818', 'ldosproject/osdk:0.18.0-ldos-20260818']
+        image: ['ldosproject/asterinas:0.18.0-ldos-20260820', 'ldosproject/osdk:0.18.0-ldos-20260820']
     steps:
       - uses: actions/checkout@v4
       - name: Run OSDK tests
@@ -72,7 +72,7 @@ jobs:
   boot-test:
     runs-on: ubuntu-latest
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
     strategy:
       fail-fast: false
@@ -93,7 +93,7 @@ jobs:
   regression-test:
     runs-on: ubuntu-latest
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
       volumes:
         # Map the following directories on the host into the container so that
@@ -124,7 +124,7 @@ jobs:
   conformance-test:
     runs-on: ubuntu-latest
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
       volumes:
         # Map the following directories on the host into the container so that
@@ -178,7 +178,7 @@ jobs:
   #       include:
   #         - name: arm-cross-boot
   #           runs_on: ubuntu-24.04-arm
-  #           image: ldosproject/asterinas:0.18.0-ldos-20260818
+  #           image: ldosproject/asterinas:0.18.0-ldos-20260820
   #           auto_test: boot
   #           enable_kvm: false
   #   runs-on: ${{ matrix.runs_on }}
@@ -195,7 +195,7 @@ jobs:
   # xfstests:
   #   runs-on: ubuntu-latest
   #   container:
-  #     image: ldosproject/asterinas:0.18.0-ldos-20260818
+  #     image: ldosproject/asterinas:0.18.0-ldos-20260820
   #     options: -v /dev:/dev --privileged
   #     volumes:
   #       - /usr/lib/google-cloud-sdk:/usr/lib/google-cloud-sdk

--- a/.github/workflows/test_x86_tdx.yml
+++ b/.github/workflows/test_x86_tdx.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        image: ['ldosproject/asterinas:0.18.0-ldos-20260818', 'ldosproject/osdk:0.18.0-ldos-20260818']
+        image: ['ldosproject/asterinas:0.18.0-ldos-20260820', 'ldosproject/osdk:0.18.0-ldos-20260820']
       fail-fast: false
     container:
       image: ${{ matrix.image }}
@@ -27,7 +27,7 @@ jobs:
   boot-test:
     runs-on: self-hosted
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
     strategy:
       fail-fast: false
@@ -50,7 +50,7 @@ jobs:
   regression-test:
     runs-on: self-hosted
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
     strategy:
       fail-fast: false
@@ -73,7 +73,7 @@ jobs:
   conformance-test:
     runs-on: self-hosted
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: -v /dev:/dev --privileged
     strategy:
       fail-fast: false

--- a/.github/workflows/test_xfstests_full.yml
+++ b/.github/workflows/test_xfstests_full.yml
@@ -10,7 +10,7 @@ jobs:
   xfstests-full:
     runs-on: ubuntu-4-cores-150GB-ssd
     container:
-      image: ldosproject/asterinas:0.18.0-ldos-20260818
+      image: ldosproject/asterinas:0.18.0-ldos-20260820
       options: --device=/dev/kvm --privileged
     timeout-minutes: 90
     steps:

--- a/.github/workflows/validate_scmls.yml
+++ b/.github/workflows/validate_scmls.yml
@@ -19,7 +19,7 @@ jobs:
   validate_scmls:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    container: ldosproject/asterinas:0.18.0-ldos-20260818
+    container: ldosproject/asterinas:0.18.0-ldos-20260820
     steps:
       - uses: actions/checkout@v4
       - name: Validate SCML files with sctrace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ All development is done inside the project Docker container:
 ```bash
 docker run -it --privileged --network=host -v /dev:/dev \
   -v $(pwd)/asterinas:/root/asterinas \
-  ldosproject/asterinas:0.18.0-ldos-20260818
+  ldosproject/asterinas:0.18.0-ldos-20260820
 ```
 
 Key Makefile targets:

--- a/book/src/kernel/README.md
+++ b/book/src/kernel/README.md
@@ -80,7 +80,7 @@ since `distro/README.md` references them -->
                 --network=host \
                 -v /dev:/dev \
                 -v $(pwd)/asterinas:/root/asterinas \
-                ldosproject/asterinas:0.18.0-ldos-20260818
+                ldosproject/asterinas:0.18.0-ldos-20260820
     ```
 
     Alternatively, if you use VS Code with the

--- a/book/src/kernel/intel-tdx.md
+++ b/book/src/kernel/intel-tdx.md
@@ -66,7 +66,7 @@ The following result is an example:
 2. Run a Docker container as the development environment.
 
     ```bash
-    docker run -it --privileged --network=host -v /dev:/dev -v $(pwd)/asterinas:/root/asterinas ldosproject/asterinas:0.18.0-ldos-20260818
+    docker run -it --privileged --network=host -v /dev:/dev -v $(pwd)/asterinas:/root/asterinas ldosproject/asterinas:0.18.0-ldos-20260820
     ```
 
 3. Inside the container,

--- a/book/src/osdk/guide/intel-tdx.md
+++ b/book/src/osdk/guide/intel-tdx.md
@@ -32,7 +32,7 @@ Therefore, it is recommended to use a Docker image to deploy the environment.
 Run a TDX Docker container:
 
 ```bash
-docker run -it --privileged --network=host -v /dev:/dev ldosproject/osdk:0.18.0-ldos-20260818
+docker run -it --privileged --network=host -v /dev:/dev ldosproject/osdk:0.18.0-ldos-20260820
 ```
 
 ## Edit `OSDK.toml` for Intel TDX support


### PR DESCRIPTION
This is the PR to update the docker image references. The previous [PR](https://github.com/ldos-project/asterinas/pull/288) was to kick off the docker image build to include the new ycsb nix file. This should only be merged after the images are finished building, so CI tests can pass. The next PR will include the ycsb benchmark script changes which will use the new nix file instead of running prepare_ycsb.