### PR TITLE
Replaced fallocate with dd in test Makefile

### DIFF
--- a/test/initramfs/Makefile
+++ b/test/initramfs/Makefile
@@ -201,7 +201,7 @@ $(EXT2_IMAGE):
 
 $(EXFAT_IMAGE):
 	@mkdir -p $(BUILD_DIR)
-	@fallocate -l 512M $(EXFAT_IMAGE)
+	@dd if=/dev/zero of=$(EXFAT_IMAGE) bs=512M count=1
 	@mkfs.exfat $(EXFAT_IMAGE)
 
 $(LTP_DEV_IMAGE):


### PR DESCRIPTION
This PR is to replace fallocate with dd for creating the exfat image. fallocate is not supported on my VM but dd is supported: 
```
fallocate: fallocate failed: Operation not supported                                                                                                                                                    
make[1]: *** [Makefile:204: /root/asterinas/test/initramfs/build/exfat.img] Error 1                                                                                                                     
make: *** [Makefile:342: initramfs] Error 2
```
Which results in a 0 byte exfat image:
`-rw-r--r-- 1 root root          0 Aug 25 15:36 test/initramfs/build/exfat.img`
