### PR TITLE
Update nixpkgs to 26.05

### DIFF
--- a/test/initramfs/nix/default.nix
+++ b/test/initramfs/nix/default.nix
@@ -14,8 +14,8 @@ let
   # Pinned nixpkgs (nix version: 2.29.1, channel: nixos-25.05, release date: 2025-07-01)
   nixpkgs = fetchTarball {
     url =
-      "https://github.com/NixOS/nixpkgs/archive/c0bebd16e69e631ac6e52d6eb439daba28ac50cd.tar.gz";
-    sha256 = "1fbhkqm8cnsxszw4d4g0402vwsi75yazxkpfx3rdvln4n6s68saf";
+      "https://github.com/NixOS/nixpkgs/archive/d57af924f160a5084293c71c2043f058bd1cdb60.tar.gz";
+    sha256 = "141q9r08vhpxbly1bzy0h4mswfjbmbjp033ncb74mav9k2xyj07f";
   };
   pkgs = import nixpkgs {
     config = { };

--- a/test/initramfs/nix/default.nix
+++ b/test/initramfs/nix/default.nix
@@ -11,7 +11,7 @@ let
   else
     throw "Target arch ${target} not yet supported.";
 
-  # Pinned nixpkgs (nix version: 2.29.1, channel: nixos-25.05, release date: 2025-07-01)
+  # Pinned nixpkgs (nix version: 2.34.8, channel: nixos-26.05, release date: 2026-08-27)
   nixpkgs = fetchTarball {
     url =
       "https://github.com/NixOS/nixpkgs/archive/d57af924f160a5084293c71c2043f058bd1cdb60.tar.gz";

--- a/test/initramfs/src/regression/process/pthread/pthread_signal_test.c
+++ b/test/initramfs/src/regression/process/pthread/pthread_signal_test.c
@@ -9,7 +9,7 @@
 #include <stdatomic.h>
 
 pthread_mutex_t mutex;
-atomic_int sync_flag = ATOMIC_VAR_INIT(0); // Atomic flag for synchronization
+atomic_int sync_flag = 0; // Atomic flag for synchronization
 
 // Signal handler for SIGUSR1
 void signal_handler(int signum)

--- a/test/initramfs/src/regression/process/signal/signal_test.c
+++ b/test/initramfs/src/regression/process/signal/signal_test.c
@@ -265,7 +265,7 @@ int test_handle_sigsegv()
 // ============================================================================
 int sigchld = 0;
 
-void proc_exit()
+void proc_exit(int signum)
 {
 	sigchld = 1;
 }


### PR DESCRIPTION
This PR is to update nixpkgs to 26.05. Previously, nixpkgs was pinned to an older version that resulted in 403 errors because crates.io no longer allows direct downloads. [This](https://github.com/NixOS/nixpkgs/pull/524985) nixpkgs update fixed the issue by pointing to static.crates.io instead. We need to upgrade our nixpkgs reference to 26.05 to include this fix. 

In addition, 26.05 upgrades the gcc compiler, which uses c23, causing one of the regression tests to fail. I fixed this by replacing ATOMIC_VAR_INIT(0) with 0, because ATOMIC_VAR_INIT is deprecated in c23? I think? Let me know if there's a better fix for this. 